### PR TITLE
add support for new index-model@0.4.0 and tests.

### DIFF
--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const async = require('async');
 const createConnection = require('mongodb-connection-model').connect;
 const getInstance = require('mongodb-instance-model').get;
+const getIndexes = require('mongodb-index-model').fetch;
 const createSampleStream = require('mongodb-collection-sample');
 const parseNamespace = require('mongodb-ns');
 
@@ -185,8 +186,7 @@ class NativeClient {
    * @param {Function} callback - The callback.
    */
   indexes(ns, callback) {
-    var coll = this._collection(ns);
-    coll.listIndexes({}).toArray((error, data) => {
+    getIndexes(this.database, ns, (error, data) => {
       if (error) {
         return callback(error);
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mongodb": "^2.1.10",
     "mongodb-collection-sample": "^1.2.0",
     "mongodb-connection-model": "^4.0.2",
+    "mongodb-index-model": "^0.4.0",
     "mongodb-instance-model": "^3.1.0",
     "mongodb-ns": "^1.0.3",
     "mongodb-url": "^1.0.2"

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -152,6 +152,7 @@ describe('DataService', function() {
       service.indexes('data-service.test', {}, function(err, indexes) {
         assert.equal(null, err);
         expect(indexes[0].name).to.equal('_id_');
+        expect(indexes[0].size).to.be.a('number');
         done();
       });
     });


### PR DESCRIPTION
@durran can you please review?

The new index model fetches information from multiple places
- `db.collection.getIndexes()` for the basics
- `db.collection.aggregate({$indexStats: {}})` for the usage
- `db.collection.stats()` for index sizes

It exposes a `fetch()` function which data-service can call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/data-service/6)
<!-- Reviewable:end -->
