### PR TITLE
INT-1510: Test an SSH tunnel is writable when creating

### DIFF
--- a/lib/ssh-tunnel-connector.js
+++ b/lib/ssh-tunnel-connector.js
@@ -3,9 +3,12 @@
 const debug = require('debug')('mongodb-data-service:ssh-tunnel-connector');
 const tunnel = require('tunnel-ssh');
 const EventEmitter = require('events');
+const net = require('net');
 
 const Events = {
   Connecting: 'SshTunnelConnector:Connecting',
+  Testing: 'SshTunnelConnector:Testing',
+  Ready: 'SshTunnelConnector:Ready',
   Error: 'SshTunnelConnector:Error'
 };
 
@@ -31,24 +34,65 @@ class SshTunnelConnector extends EventEmitter {
   /**
    * Connect to the SSH tunnel and execute the callback.
    *
-   * @param {Function} callback - The callback.
+   * @param {Function} done - The callback.
    *
    * @returns {Object} The executed callback.
    */
-  connect(callback) {
-    if (this.options.host) {
-      var connectMessage = this._connectMessage();
-      debug(connectMessage);
-      this.emit(Events.Connecting, connectMessage);
-      return tunnel(this.options, function(result, error) {
-        if (error) {
-          this.emit(Events.Error, this._errorMessage());
-        }
-        return callback(error);
-      });
+  connect(done) {
+    if (!this.options.host) {
+      debug('No SSH tunnel host option found - using direct connection.');
+      return done();
     }
-    debug('No SSH tunnel options found - using direct connection.');
-    return callback(null);
+
+    const connectMessage = this._connectMessage();
+    debug(connectMessage);
+    this.emit(Events.Connecting, connectMessage);
+
+    tunnel(this.options, (err) => {
+      if (err) {
+        this.emit(Events.Error, this._errorMessage());
+        debug('error setting up tunnel', err);
+        return done(err);
+      }
+      debug('tunnel opened - testing');
+      this.test(done);
+    }).on('error', (err) => {
+      this.emit(Events.Error, this._errorMessage());
+      debug('tunnel write failed', err);
+      done(err);
+    });
+  }
+  /**
+   * Test that a tunnel can actually be created by opening a socket
+   * to it and writing some data.
+   *
+   * @param {Function} done - The callback.
+   */
+  test(done) {
+    this.emit(Events.Testing);
+    var client = new net.Socket();
+    client.on('error', function(err) {
+      debug('test client got an error', err);
+      client.end();
+      done(err);
+    });
+
+    debug('test client connecting to %s:%s', this.options.dstHost, this.options.dstPort);
+    client.connect(this.options.dstPort, this.options.dstHost, () => {
+      debug('writing test message');
+      try {
+        client.write('mongodb-data-service:ssh-tunnel-connector: ping');
+      } catch (err) {
+        debug('write to test client failed with error', err);
+        return done(err);
+      }
+      setTimeout(() => {
+        client.end();
+        debug('test successful - emitting %s', Events.Ready);
+        this.emit(Events.Ready);
+        done(null, true);
+      }, 300);
+    });
   }
 
   /**

--- a/test/ssh-tunnel-connector.test.js
+++ b/test/ssh-tunnel-connector.test.js
@@ -1,13 +1,14 @@
-var helper = require('./helper');
+'use strict';
 
-var assert = helper.assert;
-var expect = helper.expect;
+const helper = require('./helper');
+const assert = helper.assert;
+const expect = helper.expect;
 
-var NativeClient = require('../lib/native-client');
-var fixture = require('mongodb-connection-fixture');
-var Connection = require('mongodb-connection-model');
-var SshTunnelConnector = require('../lib/ssh-tunnel-connector');
-var _ = require('lodash');
+const NativeClient = require('../lib/native-client');
+const fixture = require('mongodb-connection-fixture');
+const Connection = require('mongodb-connection-model');
+const SshTunnelConnector = require('../lib/ssh-tunnel-connector');
+const _ = require('lodash');
 
 describe('SshTunnelConnector', function() {
   this.timeout(15000);
@@ -35,4 +36,25 @@ describe('SshTunnelConnector', function() {
       });
     });
   }
+  describe('#regression', function() {
+    /**
+     * @see https://jira.mongodb.org/browse/INT-1510
+     */
+    it('should error when ssh fails', function(done) {
+      var connector = new SshTunnelConnector({
+        dstHost: 'localhost',
+        dstPort: 27107,
+        username: 'foo',
+        password: 'bar',
+        host: 'remotehost',
+        sshPort: 22
+      });
+
+      connector.connect(function(err) {
+        expect(err).not.to.equal(null, 'should have an error');
+        expect(err).not.to.equal(undefined, 'should have an error');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
ssh2 is lazily loaded essentially so in order to test failure scenarios
and ensure the tunnel is truly ready, we attempt to write against it.
This way we’ll get a proper SSH connect failure error instead of the
node.js driver connection error.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/data-service/21)
<!-- Reviewable:end -->
