### PR TITLE
INT 1851: DDL manipulation

### DIFF
--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -80,6 +80,31 @@ class DataService extends EventEmitter {
   }
 
   /**
+   * Creates a collection
+   *
+   * @param {String} ns - The namespace.
+   * @param {Object} options - The options.
+   * @param {Function} callback - The callback.
+   */
+  createCollection(ns, options, callback) {
+    debug(`#createCollection: ${ns}`);
+    this.client.createCollection(ns, options, callback);
+  }
+
+  /**
+   * Creates an index
+   *
+   * @param {String} ns - The namespace.
+   * @param {Object} spec - The index specification.
+   * @param {Object} options - The options.
+   * @param {Function} callback - The callback.
+   */
+  createIndex(ns, spec, options, callback) {
+    debug(`#createIndex: ${ns}, ${spec}`);
+    this.client.createIndex(ns, spec, options, callback);
+  }
+
+  /**
    * Get the kitchen sink information about a database and all its collections.
    *
    * @param {String} name - The database name.
@@ -122,6 +147,40 @@ class DataService extends EventEmitter {
    */
   disconnect() {
     this.client.disconnect();
+  }
+
+  /**
+   * Drops a collection from a database
+   *
+   * @param {String} ns - The namespace.
+   * @param {Function} callback - The callback.
+   */
+  dropCollection(ns, callback) {
+    debug(`#dropCollection: ${ns}`);
+    this.client.dropCollection(ns, callback);
+  }
+
+  /**
+   * Drops a database
+   *
+   * @param {String} name - The database name.
+   * @param {Function} callback - The callback.
+   */
+  dropDatabase(name, callback) {
+    debug(`#dropDatabase: ${name}`);
+    this.client.dropDatabase(name, callback);
+  }
+
+  /**
+   * Drops an index from a collection
+   *
+   * @param {String} ns - The namespace.
+   * @param {String} name - The index name.
+   * @param {Function} callback - The callback.
+   */
+  dropIndex(ns, name, callback) {
+    debug(`#dropIndex: ${ns}, ${name}`);
+    this.client.dropIndex(ns, name, callback);
   }
 
   /**

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -199,6 +199,41 @@ class NativeClient extends EventEmitter {
   }
 
   /**
+   * Creates a collection
+   *
+   * @param {String} ns - The namespace.
+   * @param {Object} options - The options.
+   * @param {Function} callback - The callback.
+   */
+  createCollection(ns, options, callback) {
+    var collectionName = this._collectionName(ns);
+    var db = this._database(this._databaseName(ns));
+    db.createCollection(collectionName, options, (error, result) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
+   * Creates an index
+   *
+   * @param {String} ns - The namespace.
+   * @param {Object} spec - The index specification.
+   * @param {Object} options - The options.
+   * @param {Function} callback - The callback.
+   */
+  createIndex(ns, spec, options, callback) {
+    this._collection(ns).createIndex(spec, options, (error, result) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
    * Get the kitchen sink information about a database and all its collections.
    *
    * @param {String} name - The database name.
@@ -271,6 +306,52 @@ class NativeClient extends EventEmitter {
    */
   disconnect() {
     this.database.close();
+  }
+
+  /**
+   * Drops a collection from a database
+   *
+   * @param {String} ns - The namespace.
+   * @param {Function} callback - The callback.
+   */
+  dropCollection(ns, callback) {
+    this._collection(ns).drop((error, result) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
+   * Drops a database
+   *
+   * @param {String} name - The database name.
+   * @param {Function} callback - The callback.
+   */
+  dropDatabase(name, callback) {
+    this._database(this._databaseName(name)).dropDatabase((error, result) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
+   * Drops an index from a collection
+   *
+   * @param {String} ns - The namespace.
+   * @param {String} name - The index name.
+   * @param {Function} callback - The callback.
+   */
+  dropIndex(ns, name, callback) {
+    this._collection(ns).dropIndex(name, (error, result) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, result);
+    });
   }
 
   /**

--- a/test/helper.js
+++ b/test/helper.js
@@ -28,3 +28,16 @@ module.exports.deleteTestDocuments = function(client, callback) {
   var collection = client.database.collection('test');
   collection.deleteMany(callback);
 };
+
+module.exports.indexes = function(client, callback) {
+  client.database.collection('test').indexes(callback);
+};
+
+module.exports.listCollections = function(client, callback) {
+  client.database.listCollections().toArray(callback);
+};
+
+module.exports.listDatabases = function(client, callback) {
+  var adminDb = client.database.admin();
+  adminDb.listDatabases(callback);
+};


### PR DESCRIPTION
To allow for DDL manipulation in Compass, I added 6 methods:
- createCollection
- dropCollection
- createIndex
- dropIndex
- createDatabase
- dropDatabase

Creating a DB wasn't as straightforward as the other operations, and I may end up altering the process as I learn more about what is required for DDL in Compass. Also, to force MongoDB to save a new DB, I had to create a collection in it, which I called "default." There may be a better way to do this, but this was the easiest method I could find.