### PR TITLE
bump mongodb-collection-sample@1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "^2.2.0",
     "lodash": "^4.6.1",
     "mongodb": "^2.2.8",
-    "mongodb-collection-sample": "^1.2.2",
+    "mongodb-collection-sample": "^1.3.0",
     "mongodb-connection-model": "^6.3.1",
     "mongodb-index-model": "^0.6.0",
     "mongodb-instance-model": "^3.1.7",


### PR DESCRIPTION
this includes the promoteValues option, which can now be passed through as part of the `options`.