### PR TITLE
require sudo in travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: false
+sudo: required
 node_js:
   - 6
 script: npm run-script ci


### PR DESCRIPTION
noticing this in different repos that use mongo-runner for tests. it seems there has been a change and we now need to enable `sudo: required` in the travis config to make these tests work. 

Similar problem here: https://github.com/mongodb-js/collection-sample/pull/81/commits/3517fc74ba5f88631f2dd6e04a18159a3552c7b9