### PR TITLE
Fix tests to deal with listCollections including system indexes in >3.2

### DIFF
--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -202,7 +202,11 @@ describe('DataService', function() {
     it('returns the collections', function(done) {
       service.listCollections('data-service', {}, function(err, collections) {
         assert.equal(null, err);
-        expect(collections).to.be.deep.equal([{ name: 'test', options: {} }]);
+        // For <3.2 system.indexes is returned with listCollections
+        expect(collections.length).to.equal(1);
+        expect(collections[0]).to.include.keys(['name', 'options']);
+        expect(collections[0].name).to.equal('test');
+        expect(collections[0].options).to.deep.equal({});
         done();
       });
     });
@@ -271,10 +275,19 @@ describe('DataService', function() {
         assert.equal(null, error);
         helper.listCollections(service.client, function(err, items) {
           assert.equal(null, err);
-          expect(items).to.deep.equal([
-            {name: 'foo', options: {}},
-            {name: 'test', options: {}}
-          ]);
+          // For <3.2 system.indexes is returned with listCollections
+          expect(items.length).to.equal(2);
+          expect(items[0]).to.include.keys(['name', 'options']);
+          expect(items[1]).to.include.keys(['name', 'options']);
+          expect(items[0].options).to.deep.equal({});
+          expect(items[1].options).to.deep.equal({});
+          if (items[0].name === 'foo') {
+            expect(items[1].name).to.equal('test');
+          } else if (items[0].name === 'test') {
+            expect(items[1].name).to.equal('foo');
+          } else {
+            assert(false, 'Collection returned from listCollections has incorrect name');
+          }
           done();
         });
       });

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -233,10 +233,19 @@ describe('NativeClient', function() {
         assert.equal(null, error);
         helper.listCollections(client, function(err, items) {
           assert.equal(null, err);
-          expect(items).to.deep.equal([
-            {name: 'foo', options: {}},
-            {name: 'test', options: {}}
-          ]);
+          // For <3.2 system.indexes is returned with listCollections
+          expect(items.length).to.equal(2);
+          expect(items[0]).to.include.keys(['name', 'options']);
+          expect(items[1]).to.include.keys(['name', 'options']);
+          expect(items[0].options).to.deep.equal({});
+          expect(items[1].options).to.deep.equal({});
+          if (items[0].name === 'foo') {
+            expect(items[1].name).to.equal('test');
+          } else if (items[0].name === 'test') {
+            expect(items[1].name).to.equal('foo');
+          } else {
+            assert(false, 'Collection returned from listCollections has incorrect name');
+          }
           done();
         });
       });


### PR DESCRIPTION
In server versions > 3.2, the system indexes are included in the listCollections call which causes our tests to fail. Changed the tests so that they check each returned collection for the correct name and options instead of comparing the entire object.

A fix for this was included in the listIndexes refactor but that PR is still on hold.

See https://github.com/mongodb-js/data-service/issues/75