### PR TITLE
COMPASS-567 - Add aggregation to data-service.

### DIFF
--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -193,6 +193,21 @@ class DataService extends EventEmitter {
   }
 
   /**
+   * Execute an aggregation framework pipeline with the provided options on the
+   * collection.
+   *
+   *
+   * @param {String} ns - The namespace to search on.
+   * @param {Object} pipeline - The aggregation pipeline.
+   * @param {Object} options - The aggregation options.
+   * @param {Function} callback - The callback function.
+   */
+  aggregate(ns, pipeline, options, callback) {
+    debug(`#aggregate: ${ns}, pipeline: ${pipeline}, options: ${options}`);
+    this.client.aggregate(ns, pipeline, options, callback);
+  }
+
+  /**
    * Find documents for the provided filter and options on the collection.
    *
    * @param {String} ns - The namespace to search on.

--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -201,10 +201,11 @@ class DataService extends EventEmitter {
    * @param {Object} pipeline - The aggregation pipeline.
    * @param {Object} options - The aggregation options.
    * @param {Function} callback - The callback function.
+   * @return {(null|AggregationCursor)}
    */
   aggregate(ns, pipeline, options, callback) {
     debug(`#aggregate: ${ns}, pipeline: ${pipeline}, options: ${options}`);
-    this.client.aggregate(ns, pipeline, options, callback);
+    return this.client.aggregate(ns, pipeline, options, callback);
   }
 
   /**

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -370,7 +370,7 @@ class NativeClient extends EventEmitter {
    *
    * @param {String} ns - The namespace to search on.
    * @param {Object} pipeline - The aggregation pipeline.
-   * @param {Object} options - The query options.
+   * @param {Object} options - The aggregation options.
    * @param {Function} callback - The callback.
    */
   aggregate(ns, pipeline, options, callback) {

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -366,7 +366,8 @@ class NativeClient extends EventEmitter {
 
   /**
    * Execute an aggregation framework pipeline with the provided options on the
-   * collection.
+   * collection. For more details, see
+   * http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#aggregate
    *
    * @param {String} ns - The namespace to search on.
    * @param {Object} pipeline - The aggregation pipeline.

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -372,9 +372,10 @@ class NativeClient extends EventEmitter {
    * @param {Object} pipeline - The aggregation pipeline.
    * @param {Object} options - The aggregation options.
    * @param {Function} callback - The callback.
+   * @return {(null|AggregationCursor)}
    */
   aggregate(ns, pipeline, options, callback) {
-    this._collection(ns).aggregate(pipeline, options, (error, result) => {
+    return this._collection(ns).aggregate(pipeline, options, (error, result) => {
       if (error) {
         return callback(this._translateMessage(error));
       }

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -365,6 +365,24 @@ class NativeClient extends EventEmitter {
   }
 
   /**
+   * Execute an aggregation framework pipeline with the provided options on the
+   * collection.
+   *
+   * @param {String} ns - The namespace to search on.
+   * @param {Object} pipeline - The aggregation pipeline.
+   * @param {Object} options - The query options.
+   * @param {Function} callback - The callback.
+   */
+  aggregate(ns, pipeline, options, callback) {
+    this._collection(ns).aggregate(pipeline, options, (error, result) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
    * Find documents for the provided filter and options on the collection.
    *
    * @param {String} ns - The namespace to search on.

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -126,6 +126,42 @@ describe('DataService', function() {
     });
   });
 
+  describe('#aggregate', function() {
+    before(function(done) {
+      helper.insertTestDocuments(service.client, function() {
+        done();
+      });
+    });
+
+    after(function(done) {
+      helper.deleteTestDocuments(service.client, function() {
+        done();
+      });
+    });
+
+    it('returns a cursor for the documents', function(done) {
+      var count = 0;
+      service.aggregate('data-service.test',
+        [{$match: {}}, {$group: {_id: '$a', total: {$sum: '$a'} } }],
+        {'cursor': { batchSize: 10000 }}
+      ).forEach(function() { count++; }, function(err) {
+        assert.equal(null, err);
+        expect(count).to.equal(2);
+        done();
+      });
+    });
+    it('returns null, calls callback', function(done) {
+      service.aggregate('data-service.test',
+        [{$match: {}}, {$group: {_id: '$a', total: {$sum: '$a'} } }],
+        {},
+        function(error, result) {
+          assert.equal(null, error);
+          expect(result.length).to.equal(2);
+          done();
+        });
+    });
+  });
+
   describe('#find', function() {
     before(function(done) {
       helper.insertTestDocuments(service.client, function() {


### PR DESCRIPTION
The first step in our charts epic is to add support for aggregation to the data service.

Aggregation calls in the driver support both callbacks and returning a cursor. Since we're going to have a large number of usages for aggregations, the data service and native client functions also support both options.