### PR TITLE
COMPASS-615 mongos detection

### DIFF
--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -47,6 +47,15 @@ class DataService extends EventEmitter {
   }
 
   /**
+   * Is the data service connected to a mongos.
+   *
+   * @returns {Boolean} If the data service is connected to a mongos.
+   */
+  isMongos() {
+    return this.client.isMongos;
+  }
+
+  /**
    * List all collections for a database.
    *
    * @param {String} databaseName - The database name.

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -720,7 +720,7 @@ class NativeClient extends EventEmitter {
    * @returns {Boolean} If the server is writable.
    */
   _isWritable(ismaster) {
-    return ismaster.ismaster === true || ismaster.msg === SHARDED;
+    return ismaster.ismaster === true || this._isMongos(ismaster);
   }
 
   /**

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -60,6 +60,7 @@ class NativeClient extends EventEmitter {
       this.database.admin().command({ ismaster: 1 }, (error, result) => {
         const ismaster = error ? {} : result;
         this.isWritable = this._isWritable(ismaster);
+        this.isMongos = this._isMongos(ismaster);
         done(null, this);
       });
     });
@@ -720,6 +721,17 @@ class NativeClient extends EventEmitter {
    */
   _isWritable(ismaster) {
     return ismaster.ismaster === true || ismaster.msg === SHARDED;
+  }
+
+  /**
+   * Determine if we are connected to a mongos
+   *
+   * @param {Object} ismaster - The ismaster response.
+   *
+   * @returns {Boolean} If the server is a mongos.
+   */
+  _isMongos(ismaster) {
+    return ismaster.msg === SHARDED;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-mongodb-js": "^2.2.0",
     "mocha": "^3.1.2",
     "mongodb-connection-fixture": "0.0.14",
+    "mock-require": "^2.0.1",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",
     "mongodb-runner": "^3.2.1",


### PR DESCRIPTION
adds `.isMongos`, similar to `.isWritable` (in fact just one of the `isWritable` conditions).

Also adding tests by mocking a `mongodb-connection-model`, just as much as the `NativeClient#connect` method is concerned. 

```
this.database.admin().command({ ismaster: 1 }, (error, result) => {
```

`this.database` is the object that needs to be mocked, that's why it looks a bit complex. 