### PR TITLE
Drop mongodb-connection-fixture from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "chai": "^3.4.1",
     "eslint-config-mongodb-js": "^2.2.0",
     "mocha": "^3.1.2",
-    "mongodb-connection-fixture": "0.0.14",
     "mock-require": "^2.0.1",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",


### PR DESCRIPTION
It’s only really used by connection-model tests.