### PR TITLE
COMPASS-810: Adding options to native client explain

### DIFF
--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -553,7 +553,7 @@ class NativeClient extends EventEmitter {
   explain(ns, filter, options, callback) {
     // @todo thomasr: driver explain() does not yet support verbosity,
     // once it does, should be passed along from the options object.
-    this._collection(ns).find(filter).explain((error, explanation) => {
+    this._collection(ns).find(filter, options).explain((error, explanation) => {
       if (error) {
         return callback(this._translateMessage(error));
       }


### PR DESCRIPTION
This is required for the explain plan to use indexes in project, skip and limit queries