### PR TITLE
Add action for initial topology description changed

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -6,7 +6,8 @@ const Reflux = require('reflux');
  * The actions that are handled by the data service.
  */
 const Actions = Reflux.createActions([
-  'connect'
+  'connect',
+  'topologyDescriptionChanged'
 ]);
 
 module.exports = Actions;

--- a/lib/data-service-store.js
+++ b/lib/data-service-store.js
@@ -23,6 +23,9 @@ const DataServiceStore = Reflux.createStore({
    */
   connect: function(model) {
     this.dataService = new DataService(model);
+    this.dataService.on('topologyDescriptionChanged', (evt) => {
+      Actions.topologyDescriptionChanged(evt);
+    });
     this.dataService.connect((error) => {
       this.trigger(error, this.dataService);
     });


### PR DESCRIPTION
When the app registry calls `onConnected` it is already too late to get any of the initial SDAM events so we provide a hook for topology description changed so they can listen to that directly, instead of subscribing to the data service directly after its already been connected to.