### PR TITLE
Bump mongodb-ns@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mongodb-index-model": "^0.6.4",
     "mongodb-instance-model": "^4.0.0",
     "mongodb-js-errors": "^0.3.0",
-    "mongodb-ns": "^1.0.3",
+    "mongodb-ns": "^2.0.0",
     "mongodb-url": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mongodb": "^2.2.28",
     "mongodb-collection-sample": "^1.6.2",
     "mongodb-connection-model": "^8.0.0",
-    "mongodb-index-model": "^0.6.4",
+    "mongodb-index-model": "^0.6.5",
     "mongodb-instance-model": "^4.0.0",
     "mongodb-js-errors": "^0.3.0",
     "mongodb-ns": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "^2.6.0",
     "lodash": "^4.6.1",
     "mongodb": "^2.2.28",
-    "mongodb-collection-sample": "^1.6.1",
+    "mongodb-collection-sample": "^1.6.2",
     "mongodb-connection-model": "^8.0.0",
     "mongodb-index-model": "^0.6.4",
     "mongodb-instance-model": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mongodb-collection-sample": "^1.6.2",
     "mongodb-connection-model": "^8.0.0",
     "mongodb-index-model": "^0.6.5",
-    "mongodb-instance-model": "^4.0.0",
+    "mongodb-instance-model": "^4.1.0",
     "mongodb-js-errors": "^0.3.0",
     "mongodb-ns": "^2.0.0",
     "mongodb-url": "^2.0.0"


### PR DESCRIPTION
Includes transitive dependency bumps as at least one is required, and just in case anything else is affected.