### PR TITLE
:arrow_up: mongodb-ns@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mongodb-index-model": "^0.6.4",
     "mongodb-instance-model": "^3.3.0",
     "mongodb-js-errors": "^0.3.0",
-    "mongodb-ns": "^1.0.3",
+    "mongodb-ns": "^2.0.0",
     "mongodb-url": "^1.0.2",
     "reflux": "^0.4.1"
   },


### PR DESCRIPTION
⚠️ Backport to `compass-1.7-releases` branch.

    npm i --save mongodb-ns@2

Hopefully COMPASS-1209 is not in the transitive dependencies as well which should hopefully appear as if automatically upgraded, but I'll find out if I need another bugfix version soon enough :)