### PR TITLE
COMPASS-1243 aggregate returns cursor when no callback is provided

### DIFF
--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -532,22 +532,29 @@ class NativeClient extends EventEmitter {
 
   /**
    * Execute an aggregation framework pipeline with the provided options on the
-   * collection. For more details, see
+   * collection. Async if called with a callback function, otherwise function
+   * returns a cursor. For more details, see
    * http://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#aggregate
    *
    * @param {String} ns - The namespace to search on.
    * @param {Object} pipeline - The aggregation pipeline.
    * @param {Object} options - The aggregation options.
-   * @param {Function} callback - The callback.
+   * @param {Function} callback - The callback (optional)
+   *
    * @return {(null|AggregationCursor)}
    */
   aggregate(ns, pipeline, options, callback) {
-    return this._collection(ns).aggregate(pipeline, options, (error, result) => {
-      if (error) {
-        return callback(this._translateMessage(error));
-      }
-      callback(null, result);
-    });
+    // async when a callback is provided
+    if (_.isFunction(callback)) {
+      this._collection(ns).aggregate(pipeline, options, (error, result) => {
+        if (error) {
+          return callback(this._translateMessage(error));
+        }
+        return callback(null, result);
+      });
+    }
+    // otherwise return cursor
+    return this._collection(ns).aggregate(pipeline, options);
   }
 
   /**


### PR DESCRIPTION
The native client's `.aggregate()` function did not return a proper cursor when a callback was passed in. This was evident by the error message that max document size 16MB was reached (which should never be the case with a cursor).

The node driver `.aggregate()` function only returns a cursor if no callback function is provided, see [this code here](https://github.com/mongodb/node-mongodb-native/blob/01b189de77569523b1ca362e96e6d88a867a0725/lib/collection.js#L2671-L2687). 

This change just mimics the node driver behaviour.