### PR TITLE
COMPASS-1342 - Example quick fix to increase test timeouts for Travis

### DIFF
--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -15,8 +15,8 @@ describe('DataService', function() {
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
     // Overrides for Travis
-    slow: 12000,
-    timeout: 12000
+    slow: 15000,
+    timeout: 15000
   }));
   after(require('mongodb-runner/mocha/after')());
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -8,8 +8,8 @@ var ObjectId = require('bson').ObjectId;
 var DataService = require('../lib/data-service');
 
 describe('DataService', function() {
-  this.slow(15000);
-  this.timeout(30000);
+  this.slow(10000);
+  this.timeout(20000);
   var service = new DataService(helper.connection);
 
   before(require('mongodb-runner/mocha/before')({

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -13,7 +13,9 @@ describe('DataService', function() {
   var service = new DataService(helper.connection);
 
   before(require('mongodb-runner/mocha/before')({
-    port: 27018
+    port: 27018,
+    slow: 15000,
+    timeout: 30000
   }));
   after(require('mongodb-runner/mocha/after')());
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -15,7 +15,7 @@ describe('DataService', function() {
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
     slow: 1000,
-    timeout: 30000
+    timeout: 1000
   }));
   after(require('mongodb-runner/mocha/after')());
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -14,7 +14,7 @@ describe('DataService', function() {
 
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
-    slow: 15000,
+    slow: 1000,
     timeout: 30000
   }));
   after(require('mongodb-runner/mocha/after')());

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -14,8 +14,9 @@ describe('DataService', function() {
 
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
-    slow: 1000,
-    timeout: 1000
+    // Overrides for Travis
+    slow: 12000,
+    timeout: 12000
   }));
   after(require('mongodb-runner/mocha/after')());
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -8,8 +8,8 @@ var ObjectId = require('bson').ObjectId;
 var DataService = require('../lib/data-service');
 
 describe('DataService', function() {
-  this.slow(1000);
-  this.timeout(20000);
+  this.slow(15000);
+  this.timeout(30000);
   var service = new DataService(helper.connection);
 
   before(require('mongodb-runner/mocha/before')({

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -15,8 +15,8 @@ describe('DataService', function() {
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
     // Overrides for Travis
-    slow: 15000,
-    timeout: 15000
+    slow: 28657,
+    timeout: 28657
   }));
   after(require('mongodb-runner/mocha/after')());
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -8,7 +8,7 @@ var ObjectId = require('bson').ObjectId;
 var DataService = require('../lib/data-service');
 
 describe('DataService', function() {
-  this.slow(10000);
+  this.slow(1000);
   this.timeout(20000);
   var service = new DataService(helper.connection);
 

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -17,8 +17,8 @@ describe('NativeClient', function() {
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
     // Overrides for Travis
-    slow: 15000,
-    timeout: 15000
+    slow: 28657,
+    timeout: 28657
   }));
 
   after(require('mongodb-runner/mocha/after')({

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -15,7 +15,9 @@ describe('NativeClient', function() {
   var client = new NativeClient(helper.connection);
 
   before(require('mongodb-runner/mocha/before')({
-    port: 27018
+    port: 27018,
+    slow: 15000,
+    timeout: 30000
   }));
 
   after(require('mongodb-runner/mocha/after')({

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -17,7 +17,7 @@ describe('NativeClient', function() {
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
     slow: 1000,
-    timeout: 30000
+    timeout: 1000
   }));
 
   after(require('mongodb-runner/mocha/after')({

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -10,8 +10,8 @@ var mock = require('mock-require');
 var NativeClient = require('../lib/native-client');
 
 describe('NativeClient', function() {
-  this.slow(1000);
-  this.timeout(20000);
+  this.slow(15000);
+  this.timeout(30000);
   var client = new NativeClient(helper.connection);
 
   before(require('mongodb-runner/mocha/before')({

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -17,8 +17,8 @@ describe('NativeClient', function() {
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
     // Overrides for Travis
-    slow: 12000,
-    timeout: 12000
+    slow: 15000,
+    timeout: 15000
   }));
 
   after(require('mongodb-runner/mocha/after')({

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -16,7 +16,7 @@ describe('NativeClient', function() {
 
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
-    slow: 15000,
+    slow: 1000,
     timeout: 30000
   }));
 

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -10,8 +10,8 @@ var mock = require('mock-require');
 var NativeClient = require('../lib/native-client');
 
 describe('NativeClient', function() {
-  this.slow(15000);
-  this.timeout(30000);
+  this.slow(10000);
+  this.timeout(20000);
   var client = new NativeClient(helper.connection);
 
   before(require('mongodb-runner/mocha/before')({

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -10,7 +10,7 @@ var mock = require('mock-require');
 var NativeClient = require('../lib/native-client');
 
 describe('NativeClient', function() {
-  this.slow(10000);
+  this.slow(1000);
   this.timeout(20000);
   var client = new NativeClient(helper.connection);
 

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -16,8 +16,9 @@ describe('NativeClient', function() {
 
   before(require('mongodb-runner/mocha/before')({
     port: 27018,
-    slow: 1000,
-    timeout: 1000
+    // Overrides for Travis
+    slow: 12000,
+    timeout: 12000
   }));
 
   after(require('mongodb-runner/mocha/after')({


### PR DESCRIPTION
This PR does some exploration into the occasional test failures, [such as this one](https://travis-ci.org/mongodb-js/data-service/jobs/251020469).

It seems very likely that this [10000ms mocha timeout](https://github.com/mongodb-js/runner/blob/569dec8/mocha/before.js#L28-L29) is responsible, so this PR overrides that for data-service until it can be determined upstream what should be done. 

Feel free to use if you just can't get Travis to pass here in data-service.