### PR TITLE
CHARTS-308: Use new stitchServiceName property in data-service

### DIFF
--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -2,6 +2,7 @@
 
 const Router = require('./router');
 const EventEmitter = require('events');
+const { CONNECTION_TYPE_VALUES } = require('mongodb-connection-model');
 
 /**
  * Instantiate a new DataService object.
@@ -20,7 +21,7 @@ class DataService extends EventEmitter {
   constructor(model) {
     super();
     this.client = null;
-    if (model.stitchClientAppId) {
+    if (model.connectionType !== CONNECTION_TYPE_VALUES.NODE_DRIVER) {
       const WebClient = require('./web-client');
       this.client = new WebClient(model);
     } else {

--- a/lib/web-client.js
+++ b/lib/web-client.js
@@ -49,7 +49,6 @@ class WebClient {
     if (this.model.stitchBaseUrl) {
       options.baseUrl = this.model.stitchBaseUrl;
     }
-    console.log(this.model);
     this.stitchClient = new StitchClient(this.model.stitchClientAppId, options);
     this.stitchClient
       .login(this.model.mongodb_username, this.model.mongodb_password)

--- a/lib/web-client.js
+++ b/lib/web-client.js
@@ -1,5 +1,6 @@
 const { StitchClient } = require('mongodb-stitch');
 const toNS = require('mongodb-ns');
+const { CONNECTION_TYPE_VALUES } = require('mongodb-connection-model');
 
 /**
  * A browser based client that wraps a stitch client instance.
@@ -48,6 +49,7 @@ class WebClient {
     if (this.model.stitchBaseUrl) {
       options.baseUrl = this.model.stitchBaseUrl;
     }
+    console.log(this.model);
     this.stitchClient = new StitchClient(this.model.stitchClientAppId, options);
     this.stitchClient
       .login(this.model.mongodb_username, this.model.mongodb_password)
@@ -129,7 +131,14 @@ class WebClient {
 
   _getCollection(ns) {
     const namespace = toNS(ns);
-    const db = this.stitchClient.service('mongodb', 'mongodb1').db(namespace.database);
+    let db;
+    if (this.model.connectionType === CONNECTION_TYPE_VALUES.STITCH_ON_PREM) {
+      db = this.stitchClient.service('mongodb', this.model.stitchServiceName)
+            .db(namespace.database);
+    } else if (this.model.connectionType === CONNECTION_TYPE_VALUES.STITCH_ATLAS) {
+      db = this.stitchClient.service('mongodb', 'mongodb-atlas').db(namespace.database);
+    }
+
     return db.collection(namespace.collection);
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lodash": "^4.6.1",
     "mongodb": "^2.2.28",
     "mongodb-collection-sample": "^2.0.0",
-    "mongodb-connection-model": "^10.2.0",
+    "mongodb-connection-model": "^10.3.0",
     "mongodb-index-model": "^1.0.0",
     "mongodb-js-errors": "^0.3.0",
     "mongodb-ns": "^2.0.0",


### PR DESCRIPTION
- use updated connection model with `connectionType` (Currently using commit hash, once things are stable use npm minor bump)
- data-service.js uses `connectionType` to switch between web-client or native-client
- web-client.js uses `stitchServiceName`