### PR TITLE
COMPASS-3035 - Reduce permissions requirements

### DIFF
--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -9,7 +9,7 @@ const map = require('lodash.map');
 const partial = require('lodash.partial');
 const has = require('lodash.has');
 const get = require('lodash.get');
-const uniq = require('lodash.uniq');
+const uniqBy = require('lodash.uniqby');
 const flatten = require('lodash.flatten');
 const groupBy = require('lodash.groupby');
 const forEach = require('lodash.foreach');
@@ -326,15 +326,16 @@ function getAllowedDatabases(results, done) {
   const userInfo = results.userInfo;
 
   // get databases on which the user is allowed to call listCollections
-  const databases = security.getResourcesWithActions(
+  let databases = security.getResourcesWithActions(
     userInfo, ['listCollections']).map(function(resource) {
       return resource.db;
-    }).filter((r) => (r));
-  const extras = security.getResourcesWithActions(
+    });
+  databases = databases.concat(security.getResourcesWithActions(
     userInfo, ['find']).map(function(resource) {
       return resource.db;
-    }).filter((r) => (r));
-  done(null, databases.concat(extras));
+    }));
+
+  done(null, databases.filter((f, i) => (f && databases.indexOf(f) === i)));
 }
 
 function parseCollection(resp) {
@@ -359,15 +360,15 @@ function getAllowedCollections(results, done) {
         name: resource.collection
       };
     });
-  const extras = (security.getResourcesWithActions(
+  collections = collections.concat(security.getResourcesWithActions(
     userInfo, ['find']).map(function(resource) {
       return {
         db: resource.db,
         name: resource.collection
       };
-    }));
+    })).filter((f) => (f.name));
 
-  collections = collections.concat(extras);
+  collections = uniqBy(collections, (c) => (`${c.db}.${c.name}`));
   collections = map(collections, parseCollection);
   debug('allowed collections', collections);
   done(null, collections);
@@ -415,7 +416,7 @@ function getCollections(results, done) {
     results.listCollections, results.allowedCollections
   ).filter((f) => (f.name !== ''));
   // de-dupe based on _id
-  collections = uniq(collections, (c) => (c._id));
+  collections = uniqBy(collections, (c) => (c._id));
 
   // @todo filter the ones that we can "count on"
   // async.filter(collections, function(collection, callback) {

--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -330,7 +330,7 @@ function getAllowedDatabases(results, done) {
     userInfo, ['listCollections']).map(function(resource) {
       return resource.db;
     }).filter((r) => (r));
-  const extras = security.getResourcesWithActions( // TODO: need find?
+  const extras = security.getResourcesWithActions(
     userInfo, ['find']).map(function(resource) {
       return resource.db;
     }).filter((r) => (r));
@@ -359,7 +359,7 @@ function getAllowedCollections(results, done) {
         name: resource.collection
       };
     });
-  const extras = (security.getResourcesWithActions( // TODO: need find?
+  const extras = (security.getResourcesWithActions(
     userInfo, ['find']).map(function(resource) {
       return {
         db: resource.db,

--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -180,7 +180,7 @@ function listDatabases(results, done) {
   const userInfo = results.userInfo;
 
   const cluster = security.getResourcesWithActions(
-    userInfo, ['listDatabases'], 'special').filter(function(resource) {
+    userInfo, ['listDatabases']).filter(function(resource) {
       return resource.cluster;
     });
 
@@ -211,6 +211,8 @@ function listDatabases(results, done) {
     const names = res.databases
       .map(function(d) {
         return d.name;
+      }).filter(function(d) {
+        return d;
       });
       // .filter(function(name) {
       //   if (name === 'admin') {
@@ -325,11 +327,14 @@ function getAllowedDatabases(results, done) {
 
   // get databases on which the user is allowed to call listCollections
   const databases = security.getResourcesWithActions(
-    userInfo, ['listCollections'], 'database').map(function(resource) {
+    userInfo, ['listCollections']).map(function(resource) {
       return resource.db;
-    });
-
-  done(null, databases);
+    }).filter((r) => (r));
+  const extras = security.getResourcesWithActions( // TODO: need find?
+    userInfo, ['find']).map(function(resource) {
+      return resource.db;
+    }).filter((r) => (r));
+  done(null, databases.concat(extras));
 }
 
 function parseCollection(resp) {
@@ -348,13 +353,21 @@ function getAllowedCollections(results, done) {
   // get collections on which the user is allowed to call find and collStats
   const compassActions = ['find', 'collStats'];
   let collections = security.getResourcesWithActions(
-    userInfo, compassActions, 'collection').map(function(resource) {
+    userInfo, compassActions).map(function(resource) {
       return {
         db: resource.db,
         name: resource.collection
       };
     });
+  const extras = (security.getResourcesWithActions( // TODO: need find?
+    userInfo, ['find']).map(function(resource) {
+      return {
+        db: resource.db,
+        name: resource.collection
+      };
+    }));
 
+  collections = collections.concat(extras);
   collections = map(collections, parseCollection);
   debug('allowed collections', collections);
   done(null, collections);
@@ -399,9 +412,10 @@ function getCollections(results, done) {
 
   // concat
   let collections = [].concat.apply(
-    results.listCollections, results.allowedCollections);
+    results.listCollections, results.allowedCollections
+  ).filter((f) => (f.name !== ''));
   // de-dupe based on _id
-  collections = uniq(collections, '_id');
+  collections = uniq(collections, (c) => (c._id));
 
   // @todo filter the ones that we can "count on"
   // async.filter(collections, function(collection, callback) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3912,10 +3912,10 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "lodash.uniqueid": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lodash.omit": "^4.5.0",
     "lodash.partial": "^4.2.1",
     "lodash.union": "^4.6.0",
-    "lodash.uniq": "^4.5.0",
+    "lodash.uniqby": "^4.5.0",
     "mongodb": "^3.1.1",
     "mongodb-collection-sample": "^3.0.0",
     "mongodb-connection-model": "^12.3.2",

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -397,6 +397,38 @@ var USER_INFO_LISTDB_ONLY = {
   ]
 };
 
+var USER_INFO_COLL_ONLY = {
+  "_id" : "db3.coll",
+  "user" : "coll",
+  "db" : "db3",
+  "roles" : [
+    {
+      "role" : "coll",
+      "db" : "db3"
+    }
+  ],
+  "inheritedRoles" : [
+    {
+      "role" : "coll",
+      "db" : "db3"
+    }
+  ],
+  "inheritedPrivileges" : [
+    {
+      "resource" : {
+        "db" : "db3",
+        "collection" : "coll3"
+      },
+      "actions" : [
+        "find",
+        "insert",
+        "update"
+      ]
+    }
+  ],
+  "inheritedAuthenticationRestrictions" : []
+};
+
 var BUILD_INFO_OLD = {
   "version" : "2.6.11",
   "gitVersion" : "d00c1735675c457f75a12d530bee85421f0c5548 modules: enterprise",
@@ -466,5 +498,6 @@ module.exports = {
   BUILD_INFO_OLD: BUILD_INFO_OLD,
   BUILD_INFO_3_2: BUILD_INFO_3_2,
   USER_INFO_JOHN: USER_INFO_JOHN,
-  USER_INFO_LISTDB_ONLY: USER_INFO_LISTDB_ONLY
+  USER_INFO_LISTDB_ONLY: USER_INFO_LISTDB_ONLY,
+  USER_INFO_COLL_ONLY: USER_INFO_COLL_ONLY
 };

--- a/test/instance-detail-helper-mocked.test.js
+++ b/test/instance-detail-helper-mocked.test.js
@@ -178,7 +178,7 @@ describe('instance-detail-helper-mocked', function() {
       getAllowedDatabases(results, function(err, res) {
         assert.equal(err, null);
         res.sort();
-        assert.deepEqual(res, ['accounts', 'products', 'reporting', 'sales']);
+        assert.deepEqual(res, ['accounts', 'products', 'reporting', 'sales', 'tenants']);
         done();
       });
     });
@@ -189,6 +189,16 @@ describe('instance-detail-helper-mocked', function() {
       getAllowedDatabases(results, function(err, res) {
         assert.equal(err, null);
         assert.deepEqual(res, []);
+        done();
+      });
+    });
+
+    it('should return readable dbs for users with no list collections', function(done) {
+      results.userInfo = fixtures.USER_INFO_COLL_ONLY;
+
+      getAllowedDatabases(results, function(err, res) {
+        assert.equal(err, null);
+        assert.deepEqual(res, ['db3']);
         done();
       });
     });
@@ -208,6 +218,78 @@ describe('instance-detail-helper-mocked', function() {
             'database': 'tenants',
             'name': 'mongodb',
             'readonly': false
+          },
+          {
+            '_id': 'reporting.system.indexes',
+            'database': 'reporting',
+            'name': 'system.indexes',
+            'readonly': false
+          },
+          {
+            '_id': 'reporting.system.js',
+            'database': 'reporting',
+            'name': 'system.js',
+            'readonly': false
+          },
+          {
+            '_id': 'reporting.system.namespaces',
+            'database': 'reporting',
+            'name': 'system.namespaces',
+            'readonly': false
+          },
+          {
+            '_id': 'products.system.indexes',
+            'database': 'products',
+            'name': 'system.indexes',
+            'readonly': false
+          },
+          {
+            '_id': 'products.system.js',
+            'database': 'products',
+            'name': 'system.js',
+            'readonly': false
+          },
+          {
+            '_id': 'products.system.namespaces',
+            'database': 'products',
+            'name': 'system.namespaces',
+            'readonly': false
+          },
+          {
+            '_id': 'sales.system.indexes',
+            'database': 'sales',
+            'name': 'system.indexes',
+            'readonly': false
+          },
+          {
+            '_id': 'sales.system.js',
+            'database': 'sales',
+            'name': 'system.js',
+            'readonly': false
+          },
+          {
+            '_id': 'sales.system.namespaces',
+            'database': 'sales',
+            'name': 'system.namespaces',
+            'readonly': false
+          },
+          {
+            '_id': 'accounts.system.indexes',
+            'database': 'accounts',
+            'name': 'system.indexes',
+            'readonly': false
+          },
+          {
+            '_id': 'accounts.system.js',
+            'database': 'accounts',
+            'name': 'system.js',
+            'readonly': false
+          },
+          {
+            '_id': 'accounts.system.namespaces',
+            'database': 'accounts',
+            'name': 'system.namespaces',
+            'readonly': false
           }
         ];
         assert.deepEqual(res, expected);
@@ -221,6 +303,23 @@ describe('instance-detail-helper-mocked', function() {
       getAllowedCollections(results, function(err, res) {
         assert.equal(err, null);
         assert.deepEqual(res, []);
+        done();
+      });
+    });
+
+    it('should return readable collections for users with no list collections', function(done) {
+      results.userInfo = fixtures.USER_INFO_COLL_ONLY;
+
+      getAllowedCollections(results, function(err, res) {
+        assert.equal(err, null);
+        assert.deepEqual(res, [
+          {
+            '_id': 'db3.coll3',
+            'database': 'db3',
+            'name': 'coll3',
+            'readonly': false
+          }
+        ]);
         done();
       });
     });


### PR DESCRIPTION
I have removed filtering of databases and collections in instance-detail-helper.js so that all collections or databases that are present in the permissions are included in the list.

This means that previously, listCollections would not return special collections like 'db.system.namespaces'/etc, and now it does.

I've tested it with an admin user, a user with DB-level auth, and a user with collection-level auth. 

@durran let me know if this is what you want and I'll update the tests.