### PR TITLE
COMPASS-3523: Add CRUD API's for Views

### DIFF
--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Router = require('./router');
 const EventEmitter = require('events');
 const { CONNECTION_TYPE_VALUES } = require('mongodb-connection-model');
@@ -11,7 +9,6 @@ const { CONNECTION_TYPE_VALUES } = require('mongodb-connection-model');
  * @param {Connection} connection - The Connection model.
  */
 class DataService extends EventEmitter {
-
   /**
    * Instantiate a new DataService object.
    *
@@ -235,6 +232,7 @@ class DataService extends EventEmitter {
 
   /**
    * Disconnect the service.
+   * @param {Function} callback - The callback.
    */
   disconnect(callback) {
     this.client.disconnect(callback);
@@ -496,6 +494,44 @@ class DataService extends EventEmitter {
    */
   top(callback) {
     this.client.top(callback);
+  }
+
+  /**
+   * Create a new view.
+   *
+   * @param {String} name - The collectionName for the view.
+   * @param {String} sourceNs - The source `<db>.<collectionOrViewName>` for the view.
+   * @param {Array} pipeline - The agggregation pipeline for the view.
+   * @param {Object} options - Options e.g. collation.
+   * @param {Function} callback - The callback.
+   * @option {Object} collation
+   */
+  createView(name, sourceNs, pipeline, options, callback) {
+    this.client.createView(name, sourceNs, pipeline, options, callback);
+  }
+
+  /**
+   * Update an existing view.
+   *
+   * @param {String} name - The collectionName for the view.
+   * @param {String} sourceNs - The source `<db>.<collectionOrViewName>` for the view.
+   * @param {Array} pipeline - The agggregation pipeline for the view.
+   * @param {Object} options - Options e.g. collation.
+   * @param {Function} callback - The callback.
+   * @option {Object} collation
+   */
+  updateView(name, sourceNs, pipeline, options, callback) {
+    this.client.updateView(name, sourceNs, pipeline, options, callback);
+  }
+
+  /**
+   * Convenience for dropping a view as a passthrough to `dropCollection()`.
+   *
+   * @param {String} ns - The namespace.
+   * @param {Function} callback - The callback.
+   */
+  dropView(ns, callback) {
+    this.client.dropView(ns, callback);
   }
 
   /**

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -818,6 +818,62 @@ class NativeClient extends EventEmitter {
   }
 
   /**
+   * Create a new view.
+   * @param {String} name - The collectionName for the view.
+   * @param {String} sourceNs - The source `<db>.<collectionOrViewName>` for the view.
+   * @param {Array} pipeline - The agggregation pipeline for the view.
+   * @param {Object} options - Options e.g. collation.
+   * @param {Function} callback - The callback.
+   * @option {Object} collation
+   */
+  createView(name, sourceNs, pipeline, options, callback) {
+    options.viewOn = this._collectionName(sourceNs);
+    options.pipeline = pipeline;
+
+    this._database(this._databaseName(sourceNs))
+      .createCollection(name, options, (error, result) => {
+        if (error) {
+          return callback(this._translateMessage(error));
+        }
+        callback(null, result);
+      });
+  }
+  /**
+   * Update a view.
+   * @param {String} name - The collectionName for the view.
+   * @param {String} sourceNs - The source `<db>.<collectionOrViewName>` for the view.
+   * @param {Array} pipeline - The agggregation pipeline for the view.
+   * @param {Object} options - Options e.g. collation.
+   * @param {Function} callback - The callback.
+   * @option {Object} collation
+   */
+  updateView(name, sourceNs, pipeline, options, callback) {
+    options.viewOn = this._collectionName(sourceNs);
+    options.pipeline = pipeline;
+
+    var collMod = { collMod: name };
+    var command = assignIn(collMod, options);
+    var db = this._database(this._databaseName(sourceNs));
+
+    db.command(command, (error, result) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
+   * Convenience for dropping a view as a passthrough to `dropCollection()`.
+   *
+   * @param {String} ns - The namespace.
+   * @param {Function} callback - The callback.
+   */
+  dropView(ns, callback) {
+    this.dropCollection(ns, callback);
+  }
+
+  /**
    * Merges the shard distribution information into the collection detail.
    *
    * @param {String} ns - The namespace.

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -824,7 +824,7 @@ describe('DataService', function() {
     });
 
     it('creates a new view', function(done) {
-      service.createView('myView', 'data-service.test', [{$project: {_id: 1, a: 0}}], {}, function(err) {
+      service.createView('myView', 'data-service.test', [{$project: {a: 0}}], {}, function(err) {
         if (err) return done(err);
         done();
       });
@@ -845,23 +845,20 @@ describe('DataService', function() {
     });
 
     it('updates the view', function(done) {
-      service.updateView('myView', 'data-service.test', [{ $project: { _id: 1, a: 1 } }], {}, function(err) {
+      service.updateView('myView', 'data-service.test', [{ $project: { a: 1 } }], {}, function(err) {
         if (err) return done(err);
         done();
       });
     });
 
     it('returns documents from the updated', function(done) {
-      service.find('data-service.myView', {}, {}, function(err, cursor) {
+      service.find('data-service.myView', {}, {}, function(err, docs) {
         if (err) return done(err);
-        cursor.toArray(function(_err, docs) {
-          if (err) return done(_err);
 
-          assert.equal(docs.length, 2);
-          assert.strictEqual(docs[0].a, 1);
-          assert.strictEqual(docs[1].a, 2);
-          done();
-        });
+        assert.equal(docs.length, 2);
+        assert.strictEqual(docs[0].a, 1);
+        assert.strictEqual(docs[1].a, 2);
+        done();
       });
     });
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -831,16 +831,13 @@ describe('DataService', function() {
     });
 
     it('returns documents from the view', function(done) {
-      service.find('data-service.myView', {}, {}, function(err, cursor) {
+      service.find('data-service.myView', {}, {}, function(err, docs) {
         if (err) return done(err);
-        cursor.toArray(function(_err, docs) {
-          if (err) return done(_err);
 
-          assert.equal(docs.length, 2);
-          assert.strictEqual(docs[0].a, undefined);
-          assert.strictEqual(docs[1].a, undefined);
-          done();
-        });
+        assert.equal(docs.length, 2);
+        assert.strictEqual(docs[0].a, undefined);
+        assert.strictEqual(docs[1].a, undefined);
+        done();
       });
     });
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -809,4 +809,73 @@ describe('DataService', function() {
       );
     });
   });
+
+  describe('#views', function() {
+    before(function(done) {
+      helper.insertTestDocuments(service.client, function() {
+        done();
+      });
+    });
+
+    after(function(done) {
+      helper.deleteTestDocuments(service.client, function() {
+        done();
+      });
+    });
+
+    it('creates a new view', function(done) {
+      service.createView('myView', 'data-service.test', [{$project: {_id: 1, a: 0}}], {}, function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+    it('returns documents from the view', function(done) {
+      service.find('data-service.myView', {}, {}, function(err, cursor) {
+        if (err) return done(err);
+        cursor.toArray(function(_err, docs) {
+          if (err) return done(_err);
+
+          assert.equal(docs.length, 2);
+          assert.strictEqual(docs[0].a, undefined);
+          assert.strictEqual(docs[1].a, undefined);
+          done();
+        });
+      });
+    });
+
+    it('updates the view', function(done) {
+      service.updateView('myView', 'data-service.test', [{ $project: { _id: 1, a: 1 } }], {}, function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
+    it('returns documents from the updated', function(done) {
+      service.find('data-service.myView', {}, {}, function(err, cursor) {
+        if (err) return done(err);
+        cursor.toArray(function(_err, docs) {
+          if (err) return done(_err);
+
+          assert.equal(docs.length, 2);
+          assert.strictEqual(docs[0].a, 1);
+          assert.strictEqual(docs[1].a, 2);
+          done();
+        });
+      });
+    });
+
+    it('drops the view', function(done) {
+      service.dropView('data-service.myView', done);
+    });
+
+    it('returns 0 documents because the view has been dropped', function(done) {
+      service.count('data-service.myView', {}, {}, function(err, _count) {
+        if (err) return done(err);
+
+        assert.equal(_count, 0);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
- [x] `service.createView()`
- [x] `service.updateView()` Using collMod
- [x] `service.dropView()`
- [x] Tests all passing
- [x] ~`getCollectionInfos()` in `instance-detail-helper` so we know a view's underlying pipeline and `sourceNs`~ Just a wrapper around exactly what we do already. Nothing specific to it.