### PR TITLE
COMPASS-2755: Extend instance details to include richer view props

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,75 @@ service.instance({}, (error, result) => {
 service.sample('database.collection', {});
 ```
 
+## Instance Details
+
+### `collections`
+
+```javascript
+[
+  {
+    _id: 'admin.system.version',
+    name: 'system.version',
+    database: 'admin',
+    readonly: false,
+    collation: null,
+    type: 'collection',
+    view_on: undefined,
+    pipeline: undefined
+  },
+  {
+    _id: 'config.system.sessions',
+    name: 'system.sessions',
+    database: 'config',
+    readonly: false,
+    collation: null,
+    type: 'collection',
+    view_on: undefined,
+    pipeline: undefined
+  },
+  {
+    _id: 'data-service.test',
+    name: 'test',
+    database: 'data-service',
+    readonly: false,
+    collation: null,
+    type: 'collection',
+    view_on: undefined,
+    pipeline: undefined
+  },
+  {
+    _id: 'data-service.system.views',
+    name: 'system.views',
+    database: 'data-service',
+    readonly: false,
+    collation: null,
+    type: 'collection',
+    view_on: undefined,
+    pipeline: undefined
+  },
+  {
+    _id: 'data-service.myView',
+    name: 'myView',
+    database: 'data-service',
+    readonly: true,
+    collation: null,
+    type: 'view',
+    view_on: 'test',
+    pipeline: [{ $project: { a: 0 } }]
+  },
+  {
+    _id: 'local.startup_log',
+    name: 'startup_log',
+    database: 'local',
+    readonly: false,
+    collation: null,
+    type: 'collection',
+    view_on: undefined,
+    pipeline: undefined
+  }
+]
+```
+
 ## License
 
 Apache 2.0

--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -25,12 +25,7 @@ const debug = require('debug')('mongodb-data-service:instance-detail-helper');
 function getStats(results, done) {
   const databases = results.databases;
 
-  const keys = [
-    'document_count',
-    'storage_size',
-    'index_count',
-    'index_size'
-  ];
+  const keys = ['document_count', 'storage_size', 'index_count', 'index_size'];
   const stats = {};
   keys.map(function(k) {
     stats[k] = 0;
@@ -121,11 +116,14 @@ function getGenuineMongoDB(results, done) {
     dbType: 'mongodb'
   };
 
-  if (buildInfo.hasOwnProperty('_t' )) {
+  if (buildInfo.hasOwnProperty('_t')) {
     res.isGenuine = false;
     res.dbType = 'cosmosdb';
   }
-  if (cmdLineOpts.hasOwnProperty('errmsg') && cmdLineOpts.errmsg.indexOf('not supported') !== -1) {
+  if (
+    cmdLineOpts.hasOwnProperty('errmsg') &&
+    cmdLineOpts.errmsg.indexOf('not supported') !== -1
+  ) {
     res.isGenuine = false;
     res.dbType = 'documentdb';
   }
@@ -200,7 +198,9 @@ function getHostInfo(results, done) {
       if (isNotAuthorized(err)) {
         // if the error is that the user is not authorized, silently ignore it
         // and return an empty document
-        debug('user does not have hostInfo privilege, returning empty document {}');
+        debug(
+          'user does not have hostInfo privilege, returning empty document {}'
+        );
         done(null, {});
         return;
       }
@@ -214,13 +214,13 @@ function getHostInfo(results, done) {
   });
 }
 
-
 function listDatabases(results, done) {
   const db = results.db;
   const userInfo = results.userInfo;
 
-  const cluster = security.getResourcesWithActions(
-    userInfo, ['listDatabases']).filter(function(resource) {
+  const cluster = security
+    .getResourcesWithActions(userInfo, ['listDatabases'])
+    .filter(function(resource) {
       return resource.cluster;
     });
 
@@ -260,7 +260,6 @@ function listDatabases(results, done) {
     done(null, names);
   });
 }
-
 
 function parseDatabase(resp) {
   return {
@@ -313,7 +312,6 @@ function getDatabase(client, db, name, done) {
   });
 }
 
-
 function getDatabases(results, done) {
   const db = results.db;
   const client = results.client;
@@ -321,32 +319,43 @@ function getDatabases(results, done) {
   // merge and de-dupe databases
   const dbnames = union(results.listDatabases, results.allowedDatabases);
 
-  async.parallel(map(dbnames, function(name) {
-    const result = partial(getDatabase, client, db, name);
-    return result;
-  }), done);
+  async.parallel(
+    map(dbnames, function(name) {
+      const result = partial(getDatabase, client, db, name);
+      return result;
+    }),
+    done
+  );
 }
-
 
 function getUserInfo(results, done) {
   const db = results.db;
 
   // get the user privileges
-  db.command({ connectionStatus: 1, showPrivileges: true }, {}, function(err, res) {
+  db.command({ connectionStatus: 1, showPrivileges: true }, {}, function(
+    err,
+    res
+  ) {
     // no auth required, if this fails there was a real problem
     if (err) {
       return done(err);
     }
-    if (!has(res, 'authInfo.authenticatedUsers') || !res.authInfo.authenticatedUsers[0]) {
+    if (
+      !has(res, 'authInfo.authenticatedUsers') ||
+      !res.authInfo.authenticatedUsers[0]
+    ) {
       debug('no logged in user, returning empty document');
       return done(null, {});
     }
     const user = res.authInfo.authenticatedUsers[0];
 
-    db.command({ usersInfo: user, showPrivileges: true }, {}, function(_err, _res) {
+    db.command({ usersInfo: user, showPrivileges: true }, {}, function(
+      _err,
+      _res
+    ) {
       if (_err) {
         // @durran: For the case usersInfo cannot be retrieved.
-        debug('Command \"usersInfo\" could not be retrieved: ' + _err.message);
+        debug('Command "usersInfo" could not be retrieved: ' + _err.message);
         return done(null, {});
       }
       // For the case azure cosmosDB bug
@@ -359,16 +368,20 @@ function getAllowedDatabases(results, done) {
   const userInfo = results.userInfo;
 
   // get databases on which the user is allowed to call listCollections
-  let databases = security.getResourcesWithActions(
-    userInfo, ['listCollections']).map(function(resource) {
+  let databases = security
+    .getResourcesWithActions(userInfo, ['listCollections'])
+    .map(function(resource) {
       return resource.db;
     });
-  databases = databases.concat(security.getResourcesWithActions(
-    userInfo, ['find']).map(function(resource) {
-      return resource.db;
-    }));
+  databases = databases.concat(
+    security
+      .getResourcesWithActions(userInfo, ['find'])
+      .map(function(resource) {
+        return resource.db;
+      })
+  );
 
-  done(null, databases.filter((f, i) => (f && databases.indexOf(f) === i)));
+  done(null, databases.filter((f, i) => f && databases.indexOf(f) === i));
 }
 
 function parseCollection(resp) {
@@ -387,22 +400,28 @@ function getAllowedCollections(results, done) {
 
   // get collections on which the user is allowed to call find and collStats
   const compassActions = ['find', 'collStats'];
-  let collections = security.getResourcesWithActions(
-    userInfo, compassActions).map(function(resource) {
+  let collections = security
+    .getResourcesWithActions(userInfo, compassActions)
+    .map(function(resource) {
       return {
         db: resource.db,
         name: resource.collection
       };
     });
-  collections = collections.concat(security.getResourcesWithActions(
-    userInfo, ['find']).map(function(resource) {
-      return {
-        db: resource.db,
-        name: resource.collection
-      };
-    })).filter((f) => (f.name));
+  collections = collections
+    .concat(
+      security
+        .getResourcesWithActions(userInfo, ['find'])
+        .map(function(resource) {
+          return {
+            db: resource.db,
+            name: resource.collection
+          };
+        })
+    )
+    .filter((f) => f.name);
 
-  collections = uniqBy(collections, (c) => (`${c.db}.${c.name}`));
+  collections = uniqBy(collections, (c) => `${c.db}.${c.name}`);
   collections = map(collections, parseCollection);
   debug('allowed collections', collections);
   done(null, collections);
@@ -435,8 +454,11 @@ function getDatabaseCollections(db, done) {
         // if the error is that the user is not authorized, silently ignore it
         // and return an empty list, same for trying to listCollections on local
         // db in Mongos
-        debug('not allowed to run `listCollections` command on %s, returning'
-          + ' empty result [].', db.databaseName);
+        debug(
+          'not allowed to run `listCollections` command on %s, returning' +
+            ' empty result [].',
+          db.databaseName
+        );
         return done(null, []);
       }
       // the command failed for another reason, report the error
@@ -444,10 +466,13 @@ function getDatabaseCollections(db, done) {
       err.command = 'listCollections';
       return done(err);
     }
-    done(null, map(res, function(d) {
-      d.db = db.databaseName;
-      return parseCollection(d);
-    }));
+    done(
+      null,
+      map(res, function(d) {
+        d.db = db.databaseName;
+        return parseCollection(d);
+      })
+    );
   });
 }
 
@@ -455,11 +480,11 @@ function getCollections(results, done) {
   // var db = results.db;
 
   // concat
-  let collections = [].concat.apply(
-    results.listCollections, results.allowedCollections
-  ).filter((f) => (f.name !== ''));
+  let collections = [].concat
+    .apply(results.listCollections, results.allowedCollections)
+    .filter((f) => f.name !== '');
   // de-dupe based on _id
-  collections = uniqBy(collections, (c) => (c._id));
+  collections = uniqBy(collections, (c) => c._id);
 
   // @todo filter the ones that we can "count on"
   // async.filter(collections, function(collection, callback) {
@@ -504,7 +529,6 @@ function getHierarchy(results, done) {
   done();
 }
 
-
 function attach(anything, done) {
   done(null, anything);
 }
@@ -530,11 +554,23 @@ function getInstanceDetail(client, db, done) {
 
     listDatabases: ['client', 'db', 'userInfo', listDatabases],
     allowedDatabases: ['userInfo', getAllowedDatabases],
-    databases: ['client', 'db', 'listDatabases', 'allowedDatabases', getDatabases],
+    databases: [
+      'client',
+      'db',
+      'listDatabases',
+      'allowedDatabases',
+      getDatabases
+    ],
 
     listCollections: ['client', 'db', 'databases', listCollections],
     allowedCollections: ['userInfo', getAllowedCollections],
-    collections: ['client', 'db', 'listCollections', 'allowedCollections', getCollections],
+    collections: [
+      'client',
+      'db',
+      'listCollections',
+      'allowedCollections',
+      getCollections
+    ],
 
     hierarchy: ['databases', 'collections', getHierarchy],
 
@@ -547,8 +583,15 @@ function getInstanceDetail(client, db, done) {
       return done(err);
     }
     // cleanup
-    results = omit(results, ['db', 'listDatabases', 'allowedDatabases',
-      'userInfo', 'listCollections', 'allowedCollections', 'cmdLineOpts']);
+    results = omit(results, [
+      'db',
+      'listDatabases',
+      'allowedDatabases',
+      'userInfo',
+      'listCollections',
+      'allowedCollections',
+      'cmdLineOpts'
+    ]);
     return done(null, results);
   });
 }
@@ -563,8 +606,10 @@ function getInstance(client, db, done) {
     let hostname;
 
     if (has(db, 's.options.url')) {
-      debug('parsing port and hostname from driver url option `%s`',
-        db.s.options.url);
+      debug(
+        'parsing port and hostname from driver url option `%s`',
+        db.s.options.url
+      );
       port = URL.port(db.s.options.url);
       hostname = URL.hostname(db.s.options.url);
     }

--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -391,7 +391,10 @@ function parseCollection(resp) {
     name: ns.collection,
     database: ns.database,
     readonly: get(resp, 'info.readOnly', false),
-    collation: get(resp, 'options.collation', null)
+    collation: get(resp, 'options.collation', null),
+    type: get(resp, 'type', 'collection'),
+    view_on: get(resp, 'options.viewOn', undefined),
+    pipeline: get(resp, 'options.pipeline', undefined)
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -412,7 +412,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -744,7 +744,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
@@ -776,7 +776,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1052,7 +1052,7 @@
     },
     "dependency-check": {
       "version": "2.10.1",
-      "resolved": "http://registry.npmjs.org/dependency-check/-/dependency-check-2.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/dependency-check/-/dependency-check-2.10.1.tgz",
       "integrity": "sha512-gmLQXELyRvWwy0IeSOMgqRvs5lotLhMO9n5932lfXhkyZ7i7wqAQ/zBoued07qRvgvo9Byol98sG8HbYKoTpNA==",
       "dev": true,
       "requires": {
@@ -3083,17 +3083,10 @@
       "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
     },
     "lodash.find": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
-      "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
-      "requires": {
-        "lodash._basecallback": "^3.0.0",
-        "lodash._baseeach": "^3.0.0",
-        "lodash._basefind": "^3.0.0",
-        "lodash._basefindindex": "^3.0.0",
-        "lodash.isarray": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+      "dev": true
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -3728,7 +3721,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
@@ -3741,7 +3734,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -4012,6 +4005,21 @@
             "lodash.sortby": "^3.1.0",
             "lodash.take": "^3.0.0",
             "lodash.without": "^3.1.0"
+          },
+          "dependencies": {
+            "lodash.find": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
+              "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
+              "requires": {
+                "lodash._basecallback": "^3.0.0",
+                "lodash._baseeach": "^3.0.0",
+                "lodash._basefind": "^3.0.0",
+                "lodash._basefindindex": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            }
           }
         },
         "ampersand-collection-rest-mixin": {
@@ -4454,19 +4462,19 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -4475,7 +4483,7 @@
         },
         "rimraf": {
           "version": "2.2.6",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
           "integrity": "sha1-xZWXVpsU2VatKcrMQr3d9fDqT0w=",
           "dev": true
         }
@@ -5641,6 +5649,21 @@
             "lodash.sortby": "^3.1.0",
             "lodash.take": "^3.0.0",
             "lodash.without": "^3.1.0"
+          },
+          "dependencies": {
+            "lodash.find": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
+              "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
+              "requires": {
+                "lodash._basecallback": "^3.0.0",
+                "lodash._baseeach": "^3.0.0",
+                "lodash._basefind": "^3.0.0",
+                "lodash._basefindindex": "^3.0.0",
+                "lodash.isarray": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+              }
+            }
           }
         },
         "ampersand-collection-rest-mixin": {
@@ -5891,7 +5914,7 @@
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "optional": true,
       "requires": {
@@ -6089,7 +6112,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "eslint-config-mongodb-js": "^2.2.0",
+    "lodash.find": "^4.6.0",
     "mocha": "^3.1.2",
     "mock-require": "^2.0.1",
     "mongodb-js-precommit": "^0.2.9",

--- a/test/instance-detail-helper-mocked.test.js
+++ b/test/instance-detail-helper-mocked.test.js
@@ -14,7 +14,6 @@ const fixtures = require('./fixtures');
 
 // var debug = require('debug')('mongodb-data-service:test:instance-detail-helper-mocked');
 
-
 describe('instance-detail-helper-mocked', function() {
   let makeMockDB;
   let makeMockClient;
@@ -113,11 +112,11 @@ describe('instance-detail-helper-mocked', function() {
     });
     it('should save a copy of the raw output', function(done) {
       const results = {
-        db: makeMockDB(null, {tester: 1})
+        db: makeMockDB(null, { tester: 1 })
       };
       getBuildInfo(results, function(err, res) {
         assert.equal(err, null);
-        assert.deepEqual(res.raw, {tester: 1});
+        assert.deepEqual(res.raw, { tester: 1 });
         done();
       });
     });
@@ -161,7 +160,7 @@ describe('instance-detail-helper-mocked', function() {
   describe('getGenuineMongoDB', function() {
     it('reports on CosmosDB', function(done) {
       const results = {
-        build: {raw: fixtures.COSMOSDB_BUILD_INFO},
+        build: { raw: fixtures.COSMOSDB_BUILD_INFO },
         cmdLineOpts: fixtures.CMD_LINE_OPTS
       };
       getGenuineMongoDB(results, function(err, res) {
@@ -173,7 +172,7 @@ describe('instance-detail-helper-mocked', function() {
     });
     it('reports on DocumentDB', function(done) {
       const results = {
-        build: {raw: fixtures.BUILD_INFO_3_2},
+        build: { raw: fixtures.BUILD_INFO_3_2 },
         cmdLineOpts: fixtures.DOCUMENTDB_CMD_LINE_OPTS
       };
       getGenuineMongoDB(results, function(err, res) {
@@ -185,7 +184,7 @@ describe('instance-detail-helper-mocked', function() {
     });
     it('should not report on 3.2', function(done) {
       const results = {
-        build: {raw: fixtures.BUILD_INFO_3_2},
+        build: { raw: fixtures.BUILD_INFO_3_2 },
         cmdLineOpts: fixtures.CMD_LINE_OPTS
       };
       getGenuineMongoDB(results, function(err, res) {
@@ -197,7 +196,7 @@ describe('instance-detail-helper-mocked', function() {
     });
     it('should not report on older versions', function(done) {
       const results = {
-        build: {raw: fixtures.BUILD_INFO_OLD},
+        build: { raw: fixtures.BUILD_INFO_OLD },
         cmdLineOpts: fixtures.CMD_LINE_OPTS
       };
       getGenuineMongoDB(results, function(err, res) {
@@ -209,13 +208,17 @@ describe('instance-detail-helper-mocked', function() {
     });
   });
 
-
   describe('getHostInfo', function() {
     it('should ignore auth errors gracefully', function(done) {
       // instead of the real db handle, pass in the mocked one
       const results = {
-        db: makeMockDB(new Error('not authorized on fooBarDatabase to execute command '
-          + '{listCollections: true, filter: {}, cursor: {}'), null)
+        db: makeMockDB(
+          new Error(
+            'not authorized on fooBarDatabase to execute command ' +
+              '{listCollections: true, filter: {}, cursor: {}'
+          ),
+          null
+        )
       };
       getHostInfo(results, function(err, res) {
         assert.equal(err, null);
@@ -246,8 +249,13 @@ describe('instance-detail-helper-mocked', function() {
 
     it('should ignore auth errors gracefully', function(done) {
       // instead of the real db handle, pass in the mocked one
-      results.db = makeMockDB(new Error('not authorized on admin to execute command '
-        + '{ listDatabases: 1.0 }'), null);
+      results.db = makeMockDB(
+        new Error(
+          'not authorized on admin to execute command ' +
+            '{ listDatabases: 1.0 }'
+        ),
+        null
+      );
 
       listDatabases(results, function(err, res) {
         assert.equal(err, null);
@@ -257,7 +265,10 @@ describe('instance-detail-helper-mocked', function() {
     });
     it('should pass on other errors from the listDatabases command', function(done) {
       // instead of the real db handle, pass in the mocked one
-      results.db = makeMockDB(new Error('some other error from hostInfo'), null);
+      results.db = makeMockDB(
+        new Error('some other error from hostInfo'),
+        null
+      );
 
       listDatabases(results, function(err, res) {
         assert.ok(err);
@@ -277,7 +288,13 @@ describe('instance-detail-helper-mocked', function() {
       getAllowedDatabases(results, function(err, res) {
         assert.equal(err, null);
         res.sort();
-        assert.deepEqual(res, ['accounts', 'products', 'reporting', 'sales', 'tenants']);
+        assert.deepEqual(res, [
+          'accounts',
+          'products',
+          'reporting',
+          'sales',
+          'tenants'
+        ]);
         done();
       });
     });
@@ -313,95 +330,134 @@ describe('instance-detail-helper-mocked', function() {
         assert.equal(err, null);
         const expected = [
           {
-            '_id': 'tenants.mongodb',
-            'database': 'tenants',
-            'name': 'mongodb',
-            'readonly': false,
-            'collation': null
+            _id: 'tenants.mongodb',
+            collation: null,
+            database: 'tenants',
+            name: 'mongodb',
+            pipeline: undefined,
+            readonly: false,
+            type: 'collection',
+            view_on: undefined
           },
           {
-            '_id': 'reporting.system.indexes',
-            'database': 'reporting',
-            'name': 'system.indexes',
-            'readonly': false,
-            'collation': null
+            _id: 'reporting.system.indexes',
+            database: 'reporting',
+            name: 'system.indexes',
+            pipeline: undefined,
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined
           },
           {
-            '_id': 'reporting.system.js',
-            'database': 'reporting',
-            'name': 'system.js',
-            'readonly': false,
-            'collation': null
+            _id: 'reporting.system.js',
+            database: 'reporting',
+            name: 'system.js',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'reporting.system.namespaces',
-            'database': 'reporting',
-            'name': 'system.namespaces',
-            'readonly': false,
-            'collation': null
+            _id: 'reporting.system.namespaces',
+            database: 'reporting',
+            name: 'system.namespaces',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'products.system.indexes',
-            'database': 'products',
-            'name': 'system.indexes',
-            'readonly': false,
-            'collation': null
+            _id: 'products.system.indexes',
+            database: 'products',
+            name: 'system.indexes',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'products.system.js',
-            'database': 'products',
-            'name': 'system.js',
-            'readonly': false,
-            'collation': null
+            _id: 'products.system.js',
+            database: 'products',
+            name: 'system.js',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'products.system.namespaces',
-            'database': 'products',
-            'name': 'system.namespaces',
-            'readonly': false,
-            'collation': null
+            _id: 'products.system.namespaces',
+            database: 'products',
+            name: 'system.namespaces',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'sales.system.indexes',
-            'database': 'sales',
-            'name': 'system.indexes',
-            'readonly': false,
-            'collation': null
+            _id: 'sales.system.indexes',
+            database: 'sales',
+            name: 'system.indexes',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'sales.system.js',
-            'database': 'sales',
-            'name': 'system.js',
-            'readonly': false,
-            'collation': null
+            _id: 'sales.system.js',
+            database: 'sales',
+            name: 'system.js',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'sales.system.namespaces',
-            'database': 'sales',
-            'name': 'system.namespaces',
-            'readonly': false,
-            'collation': null
+            _id: 'sales.system.namespaces',
+            database: 'sales',
+            name: 'system.namespaces',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'accounts.system.indexes',
-            'database': 'accounts',
-            'name': 'system.indexes',
-            'readonly': false,
-            'collation': null
+            _id: 'accounts.system.indexes',
+            database: 'accounts',
+            name: 'system.indexes',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'accounts.system.js',
-            'database': 'accounts',
-            'name': 'system.js',
-            'readonly': false,
-            'collation': null
+            _id: 'accounts.system.js',
+            database: 'accounts',
+            name: 'system.js',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'accounts.system.namespaces',
-            'database': 'accounts',
-            'name': 'system.namespaces',
-            'readonly': false,
-            'collation': null
+            _id: 'accounts.system.namespaces',
+            database: 'accounts',
+            name: 'system.namespaces',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           }
         ];
         assert.deepEqual(res, expected);
@@ -426,11 +482,14 @@ describe('instance-detail-helper-mocked', function() {
         assert.equal(err, null);
         assert.deepEqual(res, [
           {
-            '_id': 'db3.coll3',
-            'database': 'db3',
-            'name': 'coll3',
-            'readonly': false,
-            'collation': null
+            _id: 'db3.coll3',
+            database: 'db3',
+            name: 'coll3',
+            readonly: false,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           }
         ]);
         done();
@@ -441,8 +500,13 @@ describe('instance-detail-helper-mocked', function() {
   describe('getDatabaseCollections', function() {
     const results = {};
     it('should ignore auth errors gracefully', function(done) {
-      results.db = makeMockDB(new Error('not authorized on fooBarDatabase to execute command '
-        + '{listCollections: true, filter: {}, cursor: {}'), null);
+      results.db = makeMockDB(
+        new Error(
+          'not authorized on fooBarDatabase to execute command ' +
+            '{listCollections: true, filter: {}, cursor: {}'
+        ),
+        null
+      );
 
       getDatabaseCollections(results.db.admin(), function(err, res) {
         assert.equal(err, null);
@@ -452,7 +516,10 @@ describe('instance-detail-helper-mocked', function() {
     });
 
     it('should pass on other errors from the listCollections command', function(done) {
-      results.db = makeMockDB(new Error('some other error from list collections'), null);
+      results.db = makeMockDB(
+        new Error('some other error from list collections'),
+        null
+      );
 
       getDatabaseCollections(results.db.admin(), function(err, res) {
         assert.ok(err);
@@ -469,66 +536,82 @@ describe('instance-detail-helper-mocked', function() {
     beforeEach(function() {
       results.databases = [
         {
-          'name': 'accounts'
+          name: 'accounts'
         },
         {
-          'name': 'products'
+          name: 'products'
         },
         {
-          'name': 'reporting'
+          name: 'reporting'
         },
         {
-          'name': 'sales'
+          name: 'sales'
         }
       ];
     });
 
     it('should lists all collections for each listable db', function(done) {
       results.userInfo = fixtures.USER_INFO_JOHN;
-      results.db = makeMockDB(null, [{
-        'name': 'testCol',
-        'info': {
-          'readOnly': true
+      results.db = makeMockDB(null, [
+        {
+          name: 'testCol',
+          info: {
+            readOnly: true
+          }
         }
-      }]);
-      results.client = makeMockClient(null, [{
-        'name': 'testCol',
-        'info': {
-          'readOnly': true
+      ]);
+      results.client = makeMockClient(null, [
+        {
+          name: 'testCol',
+          info: {
+            readOnly: true
+          }
         }
-      }]);
+      ]);
 
       listCollections(results, function(err, res) {
         assert.equal(err, null);
         res.sort();
         const expected = [
           {
-            '_id': 'accounts.testCol',
-            'database': 'accounts',
-            'name': 'testCol',
-            'readonly': true,
-            'collation': null
+            _id: 'accounts.testCol',
+            database: 'accounts',
+            name: 'testCol',
+            readonly: true,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'products.testCol',
-            'database': 'products',
-            'name': 'testCol',
-            'readonly': true,
-            'collation': null
+            _id: 'products.testCol',
+            database: 'products',
+            name: 'testCol',
+            readonly: true,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'reporting.testCol',
-            'database': 'reporting',
-            'name': 'testCol',
-            'readonly': true,
-            'collation': null
+            _id: 'reporting.testCol',
+            database: 'reporting',
+            name: 'testCol',
+            readonly: true,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           },
           {
-            '_id': 'sales.testCol',
-            'database': 'sales',
-            'name': 'testCol',
-            'readonly': true,
-            'collation': null
+            _id: 'sales.testCol',
+            database: 'sales',
+            name: 'testCol',
+            readonly: true,
+            collation: null,
+            type: 'collection',
+            view_on: undefined,
+            pipeline: undefined
           }
         ];
         expected.sort();

--- a/test/instance-detail-helper.test.js
+++ b/test/instance-detail-helper.test.js
@@ -4,6 +4,7 @@ const connect = Connection.connect;
 const { getInstance } = require('../lib/instance-detail-helper');
 const helper = require('./helper');
 const DataService = require('../lib/data-service');
+const _ = require('lodash');
 
 describe('mongodb-data-service#instance', function() {
   describe('local', function() {
@@ -41,6 +42,7 @@ describe('mongodb-data-service#instance', function() {
 
     describe('views', function() {
       var service = new DataService(helper.connection);
+      var instanceDetails = null;
       before(function(done) {
         service.connect(function(err) {
           if (err) return done(err);
@@ -69,12 +71,28 @@ describe('mongodb-data-service#instance', function() {
         );
       });
 
-      it('includes the view details in instance details', function(done) {
+      it('gets the instance details', function(done) {
         service.instance({}, function(err, res) {
           if (err) return done(err);
-
-          console.log('res', res);
+          instanceDetails = res;
           done();
+        });
+      });
+
+      it('includes the view details in instance details', function() {
+        const viewInfo = _.find(instanceDetails.collections, [
+          '_id',
+          'data-service.myView'
+        ]);
+        assert.deepEqual(viewInfo, {
+          _id: 'data-service.myView',
+          name: 'myView',
+          database: 'data-service',
+          readonly: true,
+          collation: null,
+          type: 'view',
+          view_on: 'test',
+          pipeline: [{ $project: { a: 0 } }]
         });
       });
 


### PR DESCRIPTION
3 new properties of an item in `details.collections[]` so we can have richer metadata for views:

```
type: get(resp, 'type', 'collection'), // collection || view
view_on: get(resp, 'options.viewOn', undefined), // NOTE: this is the collection name the view is based only and not a namespace string
pipeline: get(resp, 'options.pipeline', undefined) // the view's pipeline definition 
```