### PR TITLE
COMPASS-3943: Update to latest node driver 3.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,13 +4201,14 @@
       }
     },
     "mongodb": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.2.tgz",
-      "integrity": "sha512-fqJt3iywelk4yKu/lfwQg163Bjpo5zDKhXiohycvon4iQHbrfflSAz9AIlRE6496Pm/dQKQK5bMigdVo2s6gBg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
+      "integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
       "requires": {
         "bson": "^1.1.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2"
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       }
     },
     "mongodb-collection-sample": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4201,9 +4201,9 @@
       }
     },
     "mongodb": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.3.tgz",
-      "integrity": "sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.4.tgz",
+      "integrity": "sha512-6fmHu3FJTpeZxacJcfjUGIP3BSteG0l2cxLkSrf1nnnS1OrlnVGiP9P/wAC4aB6dM6H4vQ2io8YDjkuPkje7AA==",
       "requires": {
         "bson": "^1.1.1",
         "require_optional": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash.partial": "^4.2.1",
     "lodash.union": "^4.6.0",
     "lodash.uniqby": "^4.5.0",
-    "mongodb": "^3.3.3",
+    "mongodb": "^3.3.4",
     "mongodb-collection-sample": "^4.4.3",
     "mongodb-connection-model": "^14.3.2",
     "mongodb-index-model": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash.partial": "^4.2.1",
     "lodash.union": "^4.6.0",
     "lodash.uniqby": "^4.5.0",
-    "mongodb": "^3.3.2",
+    "mongodb": "^3.3.3",
     "mongodb-collection-sample": "^4.4.3",
     "mongodb-connection-model": "^14.3.2",
     "mongodb-core": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "mongodb": "^3.3.3",
     "mongodb-collection-sample": "^4.4.3",
     "mongodb-connection-model": "^14.3.2",
-    "mongodb-core": "^3.2.7",
     "mongodb-index-model": "^2.3.0",
     "mongodb-js-errors": "^0.3.3",
     "mongodb-ns": "^2.0.0",

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -2,7 +2,6 @@ var helper = require('./helper');
 var assert = helper.assert;
 var expect = helper.expect;
 var eventStream = helper.eventStream;
-var Connection = require('mongodb-connection-model');
 var ObjectId = require('bson').ObjectId;
 var mock = require('mock-require');
 
@@ -99,21 +98,6 @@ describe('NativeClient', function() {
         mockedClient.connect(function() {
           /* eslint no-unused-expressions: 0 */
           expect(mockedClient.isWritable).to.be.true;
-        });
-      });
-    });
-
-    context('when an invalid connection was provided', function() {
-      var badConnection = new Connection({
-        hostname: '127.0.0.1',
-        port: 27050,
-        ns: 'data-service'
-      });
-      var badClient = new NativeClient(badConnection);
-      it('maps the error message', function(done) {
-        badClient.connect(function(error) {
-          expect(error.message).to.include('connect');
-          done();
         });
       });
     });
@@ -782,20 +766,6 @@ describe('NativeClient', function() {
             }
           );
         });
-      });
-    });
-  });
-
-  describe('#disconnect', function() {
-    after(function(done) {
-      client.connect(done);
-    });
-
-    it('disconnects the database', function(done) {
-      client.disconnect();
-      client.count('data-service.test', {}, {}, function(error) {
-        expect(error.message).to.include('destroyed');
-        done();
       });
     });
   });


### PR DESCRIPTION
## Description

This PR updates the node.js driver from `3.3.2` to the latest release `3.3.4`. It contains many improvements and bug fixes. [The full changelog is below](#node-changelog). 

**Changelog Highlights**

### High Priority SDAM Fixes

> [NODE-2274](https://jira.mongodb.org/browse/NODE-2274) "Unified topology never regains nodes which temporarily go down" 

Fixes the underlying cause of timeout-related errors such as "Server selection timed out" with more details in COMPASS-3849 COMPASS-3728. The pull request mongodb/node-mongodb-native#2197 contains much more context on the fix, and a [new design document](https://github.com/mongodb/node-mongodb-native/blob/master/docs/reference/content/reference/unified-topology/index.md) includes how and why the node.js driver team chose this architecture and future improvements it will enable.

### Fix unsafe Buffer usage

> **connect:** Switch new Buffer(size) -> Buffer.alloc(size) ([da90c3a](https://github.com/mongodb/node-mongodb-native/commit/da90c3a))

Removes the last unsafe buffer usage warning from the devtools console/terminal output when using or developing Compass. Rejoice!

### Update from an Aggregation Pipeline

> **Update:** add the ability to specify a pipeline to an update command ([#2017](https://github.com/mongodb/node-mongodb-native/issues/2017)) ([44a4110](https://github.com/mongodb/node-mongodb-native/commit/44a4110))

While it has yet to come up, it is worth noting for the future that Compass can now technically add support for [updates in aggregation pipeline stages](https://www.mongodb.com/blog/post/coming-in-mongodb-42-pipeline-powered-updates-and-more-expressive-queries) which are new in MongoDB 4.2.

### `sdam_viz`

> **sdam_viz:** add new tool for visualizing driver sdam changes ([738189a](https://github.com/mongodb/node-mongodb-native/commit/738189a))

An internal tool for debugging SDAM (Server Discovery and Monitoring) that could be used as a base for a more productive connection debugging feature in Compass or merely adding to `data-service` debug logs.

### mongodb-core "deprecation"

The `mongodb-core` dependency has been removed from `mongodb-data-service` because it has been moved back into the driver codebase as of `~mongodb@3.3.0`. `mongodb-core` will be officially deprecated in the future by the driver team.

<a name="node-changelog"></a>

## node.js driver changelog

[Diff v3.3.2...v3.3.4](https://github.com/mongodb/node-mongodb-native/compare/v3.3.2...v3.3.4)

> ## [3.3.4](https://github.com/mongodb/node-mongodb-native/compare/v3.3.3...v3.3.4) (2019-11-11)
> 
> 
> ### Bug Fixes
> 
> * **close:** the unified topology emits a close event on close now ([ee0db01](https://github.com/mongodb/node-mongodb-native/commit/ee0db01))
> * **connect:** prevent multiple callbacks in error scenarios ([5f6a787](https://github.com/mongodb/node-mongodb-native/commit/5f6a787))
> * **monitoring:** incorrect states used to determine rescheduling ([ec1e04c](https://github.com/mongodb/node-mongodb-native/commit/ec1e04c))
> * **pool:** don't reset a pool if we'not already connected ([32316e4](https://github.com/mongodb/node-mongodb-native/commit/32316e4))
> * **pool:** only transition to `DISCONNECTED` if reconnect enabled ([43d461e](https://github.com/mongodb/node-mongodb-native/commit/43d461e))
> * **replset:** don't leak servers failing to connect ([f209160](https://github.com/mongodb/node-mongodb-native/commit/f209160))
> * **replset:** use correct `topologyId` for event emission ([19549ff](https://github.com/mongodb/node-mongodb-native/commit/19549ff))
> * **sdam:** `minHeartbeatIntervalMS` => `minHeartbeatFrequencyMS` ([af9fb45](https://github.com/mongodb/node-mongodb-native/commit/af9fb45))
> * **sdam:** don't emit `close` every time a child server closes ([818055a](https://github.com/mongodb/node-mongodb-native/commit/818055a))
> * **sdam:** don't lose servers when they fail monitoring ([8a534bb](https://github.com/mongodb/node-mongodb-native/commit/8a534bb))
> * **sdam:** don't remove unknown servers in topology updates ([1147ebf](https://github.com/mongodb/node-mongodb-native/commit/1147ebf))
> * **sdam:** ignore server errors when closing/closed ([49d7235](https://github.com/mongodb/node-mongodb-native/commit/49d7235))
> * **server:** don't emit error in connect if closing/closed ([62ada2a](https://github.com/mongodb/node-mongodb-native/commit/62ada2a))
> * **server:** ensure state is transitioned to closed on connect fail ([a471707](https://github.com/mongodb/node-mongodb-native/commit/a471707))
> * **topology:** report unified topology as `nodejs` ([d126665](https://github.com/mongodb/node-mongodb-native/commit/d126665))
> * **topology:** set max listeners to infinity for db event relay ([edb1335](https://github.com/mongodb/node-mongodb-native/commit/edb1335))
> 
> 
> ### Features
> 
> * **sdam_viz:** add new tool for visualizing driver sdam changes ([738189a](https://github.com/mongodb/node-mongodb-native/commit/738189a))
> * **sdam_viz:** support legacy topologies in sdam_viz tool ([1a5537e](https://github.com/mongodb/node-mongodb-native/commit/1a5537e))
> * **update-hints:** add support for `hint` to all update methods ([720f5e5](https://github.com/mongodb/node-mongodb-native/commit/720f5e5))


> ## [3.3.3](https://github.com/mongodb/node-mongodb-native/compare/v3.3.2...v3.3.3) (2019-10-16)
> 
> 
> ### Bug Fixes
> 
> * **change_stream:** emit 'close' event if reconnecting failed ([f24c084](https://github.com/mongodb/node-mongodb-native/commit/f24c084))
> * **ChangeStream:** remove startAtOperationTime once we have resumeToken ([362afd8](https://github.com/mongodb/node-mongodb-native/commit/362afd8))
> * **connect:** Switch new Buffer(size) -> Buffer.alloc(size) ([da90c3a](https://github.com/mongodb/node-mongodb-native/commit/da90c3a))
> * **MongoClient:** only check own properties for valid options ([9cde4b9](https://github.com/mongodb/node-mongodb-native/commit/9cde4b9))
> * **mongos:** disconnect proxies which are not mongos instances ([ee53983](https://github.com/mongodb/node-mongodb-native/commit/ee53983))
> * **mongos:** force close servers during reconnect flow ([186263f](https://github.com/mongodb/node-mongodb-native/commit/186263f))
> * **monitoring:** correct spelling mistake for heartbeat event ([21aa117](https://github.com/mongodb/node-mongodb-native/commit/21aa117))
> * **replset:** correct server leak on initial connect ([da39d1e](https://github.com/mongodb/node-mongodb-native/commit/da39d1e))
> * **replset:** destroy primary before removing from replsetstate ([45ac09a](https://github.com/mongodb/node-mongodb-native/commit/45ac09a))
> * **replset:** destroy servers that are removed during SDAM flow ([9ea0190](https://github.com/mongodb/node-mongodb-native/commit/9ea0190))
> * **saslprep:** add in missing saslprep dependency ([41f1165](https://github.com/mongodb/node-mongodb-native/commit/41f1165))
> * **topology:** don't early abort server selection on network errors ([2b6a359](https://github.com/mongodb/node-mongodb-native/commit/2b6a359))
> * **topology:** don't emit server closed event on network error ([194dcf0](https://github.com/mongodb/node-mongodb-native/commit/194dcf0))
> * **topology:** include all BSON types in ctor for bson-ext support ([aa4c832](https://github.com/mongodb/node-mongodb-native/commit/aa4c832))
> * **topology:** respect the `force` parameter for topology close ([d6e8936](https://github.com/mongodb/node-mongodb-native/commit/d6e8936))
> 
> ### Features
> 
> * **Update:** add the ability to specify a pipeline to an update command ([#2017](https://github.com/mongodb/node-mongodb-native/issues/2017)) ([44a4110](https://github.com/mongodb/node-mongodb-native/commit/44a4110))
> * **urlParser:** default useNewUrlParser to true ([52d76e3](https://github.com/mongodb/node-mongodb-native/commit/52d76e3))

## Checklist

- [x] Tests have been updated

Two tests were failing with this update because of assumptions made on much older releases of the driver. These tests were for smoke testing functional side effects only, for example, calling count() after disconnect() always throws an immediate error. I've removed them. correct2aac96d208122cd2a92132d2dff2740eaca5cd87

> 1. Test connectivity with `mongodb-connection-model#test()` not via a connect() call because a test should use different timeout values than a connection that will be used more than once. In the case of this test, the selection timeout in the driver is 30000ms, which caused this test to fail with `exceeded test timeout of 2000`.
> 
> 2. The driver supports retryable reads and writes, which invalidates the state the `disconnect()` test relied upon, resulting in a `Topology Destroyed` error for subsequent calls to the client once closed. Like #1 above, after 30000ms, the `count()` would eventually error, but again, there are already other test cases covering these code paths.

## Motivation and Context

- [x] Dependency update [`mongodb@3.3.4`](#node-changelog) from `mongodb@3.3.2`

## Dependents

Depended on by mongodb-js/compass#1834

## Types of changes

- [x] Patch (non-breaking change which fixes an issue)