### PR TITLE
COMPASS-3971 clean uri from an empty compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4228,9 +4228,9 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "14.3.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-14.3.4.tgz",
-      "integrity": "sha512-92IBYwoKRt+1KyiCHQONyBb/yIsdIcLEYdUKpY2ltewB5GQt3EcmvVoyhs5pd5bFhfYaSQcwXGNanV7XSCeffA==",
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-14.3.5.tgz",
+      "integrity": "sha512-oNxtBeD5KSZdufTReXp31HNmK0hDuSP8ATRzaYFr1b/pP2OjlRVPSJgjAT2i3QJlqinpzb9YBNguYi5kzVXbGQ==",
       "requires": {
         "ampersand-model": "^8.0.0",
         "ampersand-rest-collection": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash.uniqby": "^4.5.0",
     "mongodb": "^3.3.4",
     "mongodb-collection-sample": "^4.4.3",
-    "mongodb-connection-model": "^14.3.4",
+    "mongodb-connection-model": "^14.3.5",
     "mongodb-index-model": "^2.3.0",
     "mongodb-js-errors": "^0.3.3",
     "mongodb-ns": "^2.0.0",


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Ude a new version of the connection model without empty compression in uri

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
