### PR TITLE
feat(ci): Integration test latest stable and unstable server releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: bionic
 language: node_js
 addons:
   apt:
@@ -14,7 +14,8 @@ addons:
 node_js:
   - 12.4.0
 env:
-  - MONGODB_VERSION=4.0.0 MONGODB_TOPOLOGY=standalone
+  - MONGODB_VERSION=stable MONGODB_TOPOLOGY=standalone
+  - MONGODB_VERSION=unstable MONGODB_TOPOLOGY=standalone
 before_install:
   - npm i -g npm
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+      - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
       - libkrb5-dev
       - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ addons:
       - libkrb5-dev
       - xvfb
       - libsecret-1-dev
-      - gnome-keyring
-      - python-gnomekeyring
 node_js:
   - 12.4.0
 env:


### PR DESCRIPTION
## Description

Thanks to the findings in mongodb-js/collection-sample#96 we can update config yaml to get travis back to integration testing latest stable and unstable releases. 

## Motivation and Context

> Related COMPASS-3820:

### dist: bionic 

We were on `trusty` (Ubuntu 14.04) which mdb server no longer supports resulting in `mongodb-version-manager` failing to download server installer assets. Simply switching to `bionic` (Ubuntu 18.04) and now we can download those assets correctly again.

### Disallowing sources: ubuntu-toolchain-r-test

travis-ci/apt-source-safelist#410 

Provides the second required update for `ppa:ubuntu-toolchain-r/test`

https://github.com/travis-ci/apt-source-safelist/issues/410#issuecomment-533555025

### E: Package 'python-gnomekeyring' has no installation candidate

Appears to have gone away. Some other modules like mongodb-js/storage-mixin need to unlock keychain in CI so we can hunt for more details then.

https://askubuntu.com/questions/1080896/what-replaced-pythons-gnomekeyring-module-in-ubuntu-18-04-bionic

- [x] Misc

## Types of changes

- [x] Patch (non-breaking change which fixes an issue)
