### PR TITLE
COMPASS-4315: use driver's srvHost

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3128,9 +3128,9 @@
       "dev": true
     },
     "localforage": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
-      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.4.tgz",
+      "integrity": "sha512-3EmVZatmNVeCo/t6Te7P06h2alGwbq8wXlSkcSXMvDE2/edPmsVqTPlzGnZaqwZZDBs6v+kxWpqjVsqsNJT8jA==",
       "requires": {
         "lie": "3.1.1"
       }
@@ -4077,19 +4077,39 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.2.tgz",
-      "integrity": "sha512-05rCV05dLOYrZ55Zle5fi3YZIkzRH17c0vWRxaP+ueB/2EwbtUIWZ/jxFPqHjoqaJPTHeElHN1X5lxEJ6pPrxQ==",
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.4.tgz",
+      "integrity": "sha512-QxLAuqlhxTb9b3ErklkIwx8ClPcrgQ1yMh/G7ARDqI8a/c4EFnBgbzRmtPa9XKgX30Yu1Ur7NM4RzDm4V2V3Sg==",
       "requires": {
         "ampersand-model": "^8.0.0",
         "ampersand-rest-collection": "^6.0.0",
         "async": "^3.1.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.15",
-        "mongodb": "^3.5.7",
+        "mongodb": "^3.5.9",
         "raf": "^3.4.1",
         "ssh2": "^0.8.7",
         "storage-mixin": "^3.3.3"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
+        },
+        "mongodb": {
+          "version": "3.5.9",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.9.tgz",
+          "integrity": "sha512-vXHBY1CsGYcEPoVWhwgxIBeWqP3dSu9RuRDsoLRPTITrcrgm1f0Ubu1xqF9ozMwv53agmEiZm0YGo+7WL3Nbug==",
+          "requires": {
+            "bl": "^2.2.0",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        }
       }
     },
     "mongodb-core": {
@@ -4710,9 +4730,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.17.0.tgz",
-      "integrity": "sha512-dFRAA0ACk/aBo0TIXQMEWMLUTyWYYT8OBYIzLmEUrQTElGRjxDCvyBZIsDL0QA7QCaj9PrawhOmTEdsuLY4uOQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
+      "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -5871,9 +5891,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
-      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
       "requires": {
         "bl": "^4.0.1",
         "end-of-stream": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.15",
     "mongodb": "^3.5.7",
     "mongodb-collection-sample": "^4.5.1",
-    "mongodb-connection-model": "^16.1.2",
+    "mongodb-connection-model": "^16.1.4",
     "mongodb-index-model": "^2.6.1",
     "mongodb-js-errors": "^0.5.0",
     "mongodb-ns": "^2.2.0",


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Bump the `connection-model` version to one that uses driver's srvHost to get rid of extra pasring on our side.

If this PR approved, and I am OOO, pls create Compass' PR for bumping `data-service` and `connection-model` versions in dependencies and ask @mmarcon to reply on https://jira.mongodb.org/browse/COMPASS-4315

More info here: https://github.com/mongodb-js/connection-model/pull/295

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
