### PR TITLE
COMPASS-4345: Add findOneAndUpdate

### DIFF
--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -325,6 +325,19 @@ class DataService extends EventEmitter {
   }
 
   /**
+   * Find one document and update it with the update operations.
+   *
+   * @param {String} ns - The namespace to search on.
+   * @param {Object} filter - The filter.
+   * @param {Object} update - The update operations doc.
+   * @param {Object} options - The query options.
+   * @param {Function} callback - The callback.
+   */
+  findOneAndUpdate(ns, filter, update, options, callback) {
+    this.client.findOneAndUpdate(ns, filter, update, options, callback);
+  }
+
+  /**
    * Returns explain plan for the provided filter and options on the collection.
    *
    * @param {String} ns - The namespace to search on.

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -630,6 +630,29 @@ class NativeClient extends EventEmitter {
   }
 
   /**
+   * Find one document and update it with the update operations.
+   *
+   * @param {String} ns - The namespace to search on.
+   * @param {Object} filter - The filter.
+   * @param {Object} update - The update operations doc.
+   * @param {Object} options - The query options.
+   * @param {Function} callback - The callback.
+   */
+  findOneAndUpdate(ns, filter, update, options, callback) {
+    this._collection(ns).findOneAndUpdate(
+      filter,
+      update,
+      options,
+      (error, result) => {
+        if (error) {
+          return callback(this._translateMessage(error));
+        }
+        callback(null, result.value);
+      }
+    );
+  }
+
+  /**
    * Returns explain plan for the provided filter and options on the collection.
    *
    * @param {String} ns - The namespace to search on.

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -317,6 +317,51 @@ describe('DataService', function() {
     });
   });
 
+  describe('#findOneAndUpdate', function() {
+    after(function(done) {
+      helper.deleteTestDocuments(service.client, function() {
+        done();
+      });
+    });
+
+    var id = new ObjectId();
+
+    it('returns the updated document', function(done) {
+      service.insertOne(
+        'data-service.test',
+        {
+          _id: id,
+          a: 500
+        },
+        {},
+        function(err) {
+          assert.equal(null, err);
+          service.findOneAndUpdate(
+            'data-service.test',
+            {
+              _id: id
+            },
+            {
+              $set: {
+                b: 5
+              }
+            },
+            {
+              returnOriginal: false
+            },
+            function(error, result) {
+              expect(error).to.equal(null);
+              expect(result._id.toString()).to.deep.equal(id.toString());
+              expect(result.b).to.equal(5);
+              expect(result.hasOwnProperty('a')).to.equal(true);
+              done();
+            }
+          );
+        }
+      );
+    });
+  });
+
   describe('#collection', function() {
     it('returns the collection details', function(done) {
       service.collection('data-service.test', {}, function(err, coll) {


### PR DESCRIPTION
COMPASS-4345

This PR adds the method `findOneAndUpdate` to the data service so that compass-crud can use it. Previously we were using `findOneAndUpdate`. We're switching to `findOneAndUpdate` to provide a better experience to the user in the cases where a document was modified in the background between when they were shown the document and they perform updates. 