### PR TITLE
COMPASS-4116: Fix datalake telemetry - update datalake check to use build info package

### DIFF
--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -4,6 +4,7 @@ const toNS = require('mongodb-ns');
 const security = require('mongodb-security');
 const ReadPreference = require('mongodb').ReadPreference;
 const URL = require('mongodb-url');
+const getMongoDBBuildInfo = require('mongodb-build-info');
 const {
   union,
   map,
@@ -142,17 +143,14 @@ function getGenuineMongoDB(results, done) {
 function getDataLake(results, done) {
   const buildInfo = results.build.raw;
 
-  debug('isDataLake check: buildInfo.queryEngine', buildInfo.queryEngine);
+  debug('isDataLake check: buildInfo.dataLake', buildInfo.dataLake);
+
+  const { isDataLake, dlVersion } = getMongoDBBuildInfo.getDataLake(buildInfo);
 
   const res = {
-    isDataLake: false,
-    version: null
+    isDataLake,
+    version: dlVersion
   };
-
-  if (buildInfo.queryEngine) {
-    res.isDataLake = true;
-    res.version = buildInfo.queryEngine.version;
-  }
 
   done(null, res);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4049,6 +4049,11 @@
         }
       }
     },
+    "mongodb-build-info": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
+      "integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
+    },
     "mongodb-collection-sample": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
     "mongodb": "^3.5.7",
+    "mongodb-build-info": "^1.1.0",
     "mongodb-collection-sample": "^4.5.1",
     "mongodb-connection-model": "^16.1.4",
     "mongodb-index-model": "^2.6.1",

--- a/test/instance-detail-helper-mocked.test.js
+++ b/test/instance-detail-helper-mocked.test.js
@@ -233,12 +233,18 @@ describe('instance-detail-helper-mocked', function() {
   describe('getDataLake', function() {
     it('reports when connected to DataLake', function(done) {
       const results = {
-        build: { raw: { queryEngine: { version: '1.0.0' } } }
+        build: { raw: {
+          dataLake: {
+            version: 'v20200329',
+            gitVersion: '0f318ss78bfad79ede3721e91iasj6f61644f',
+            date: '2020-03-29T15:41:22Z'
+          }
+        } }
       };
       getDataLake(results, function(err, res) {
         assert.equal(err, null);
         assert.equal(res.isDataLake, true);
-        assert.equal(res.version, '1.0.0');
+        assert.equal(res.version, 'v20200329');
         done();
       });
     });


### PR DESCRIPTION
COMPASS-4116

Now we're using the more up to date https://github.com/mongodb-js/mongodb-build-info for getting data lake (vscode and mongosh use this package). Previously we were seeing if it was datalake based on the `queryEngine` in the `buildInfo`. Now there's a datalake prop. Not sure when changed, haven't looked deeper.

Before:
<img width="483" alt="Screen Shot 2020-08-05 at 11 27 30 AM" src="https://user-images.githubusercontent.com/1791149/89396308-acfd0b00-d70e-11ea-85db-e5cc12903531.png">


After:
<img width="482" alt="Screen Shot 2020-08-05 at 11 22 07 AM" src="https://user-images.githubusercontent.com/1791149/89395803-14ff2180-d70e-11ea-959e-21c95c602559.png">
