### PR TITLE
COMPASS-4319: Bump mongodb driver to 3.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4030,9 +4030,9 @@
       }
     },
     "mongodb": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.7.tgz",
-      "integrity": "sha512-lMtleRT+vIgY/JhhTn1nyGwnSMmJkJELp+4ZbrjctrnBxuLbj6rmLuJFz8W2xUzUqWmqoyVxJLYuC58ZKpcTYQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.1.tgz",
+      "integrity": "sha512-uH76Zzr5wPptnjEKJRQnwTsomtFOU/kQEU8a9hKHr2M7y9qVk7Q4Pkv0EQVp88742z9+RwvsdTw6dRjDZCNu1g==",
       "requires": {
         "bl": "^2.2.0",
         "bson": "^1.1.4",
@@ -4043,9 +4043,9 @@
       },
       "dependencies": {
         "bson": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "async": "^3.2.0",
     "debug": "^4.1.1",
     "lodash": "^4.17.15",
-    "mongodb": "^3.5.7",
+    "mongodb": "^3.6.1",
     "mongodb-build-info": "^1.1.0",
     "mongodb-collection-sample": "^4.5.1",
     "mongodb-connection-model": "^16.1.5",


### PR DESCRIPTION
Pulls in https://github.com/mongodb/node-mongodb-native/releases/tag/v3.6.1

Which should fix Compass-4319 and maybe Compass-4203

Once this is merged we can bump the mongodb version in the main compass repo and the version of this package.