### PR TITLE
COMPASS-4353 - Do not report bogus readonly key from collectionStats

### DIFF
--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -381,7 +381,7 @@ class NativeClient extends EventEmitter {
         this._buildCollectionStats(
           databaseName,
           collectionName,
-          data || { readonly: true }
+          data || {}
         )
       );
     });
@@ -1031,7 +1031,6 @@ class NativeClient extends EventEmitter {
       size: data.size,
       index_details: data.indexDetails || {},
       wired_tiger: data.wiredTiger || {},
-      readonly: data.readonly || false
     };
   }
 

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -406,6 +406,19 @@ describe('NativeClient', function() {
           done();
         });
       });
+
+      // collectionStats() used to provide a `readonly: <boolean>` key, but
+      // since the underlying database command does not provide one, the value
+      // was bogus. Make sure that we're not accidentally providing an incorrect
+      // value.
+      it('does not provide a readonly key', function(done) {
+        client.collectionStats('data-service', 'test', function(err, stats) {
+          assert.equal(null, err);
+          expect(stats.name).to.equal('test');
+          expect(Object.keys(stats)).to.not.include('readonly');
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
`collStats` does not provide the `readonly` information, so don’t
make up a possibly incorrect value and instead omit the key.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
