### PR TITLE
COMPASS-4380: Bump mongodb-connection-model to 17.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4082,9 +4082,9 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-16.1.6.tgz",
-      "integrity": "sha512-eR38NXs99g9u6kZdmw8sUR8ggJeEb5rXuu2IHS0hvyO1R4W0EaKAXf+uhefZEJ9laPJyGTHm1UGlPQWlHH/XTg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-17.0.0.tgz",
+      "integrity": "sha512-/HeiuT5fuUlOsmycMwmi8QVqXv5J/ms2TJMdfhO9cG2Vf0oYjvrLVHVtOJIlSaDBeoicFR1TXNAh8mTwCgvfGg==",
       "requires": {
         "ampersand-model": "^8.0.0",
         "ampersand-rest-collection": "^6.0.0",
@@ -4094,7 +4094,7 @@
         "mongodb": "^3.6.1",
         "raf": "^3.4.1",
         "ssh2": "^0.8.7",
-        "storage-mixin": "^3.3.3"
+        "storage-mixin": "^3.3.4"
       }
     },
     "mongodb-core": {
@@ -5876,11 +5876,11 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-      "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mongodb": "^3.6.1",
     "mongodb-build-info": "^1.1.0",
     "mongodb-collection-sample": "^4.5.1",
-    "mongodb-connection-model": "^16.1.6",
+    "mongodb-connection-model": "^17.0.0",
     "mongodb-index-model": "^2.6.1",
     "mongodb-js-errors": "^0.5.0",
     "mongodb-ns": "^2.2.0",


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

Uses a new `mongodb-connection-model` that does not try to add the scheme if missing.

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [ ] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [x] Major (fix or feature that would cause existing functionality to change)
