### PR TITLE
deps: bump connection model for removal of x509 username validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4206,9 +4206,9 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-17.0.3.tgz",
-      "integrity": "sha512-P30yCR1V1e/uq81MBpMWl5Th+Qx2WvymE3JocfU3NF8ggrUFJsyEWrjMBi+6hD+qTxUF2N/tw9F/YC6rNCMHVw==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-17.1.0.tgz",
+      "integrity": "sha512-RibS2JfxbVEmjDfuRC3zfaoweOGFvUfEy9JmgYDcGOrhcKcUj4z/VUlbD+6bsg47vImpgMXvXWr22BgjKL4PQw==",
       "requires": {
         "ampersand-model": "^8.0.0",
         "ampersand-rest-collection": "^6.0.0",
@@ -4845,9 +4845,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
-      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
       "requires": {
         "semver": "^5.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mongodb": "^3.6.3",
     "mongodb-build-info": "^1.1.1",
     "mongodb-collection-sample": "^4.5.1",
-    "mongodb-connection-model": "^17.0.3",
+    "mongodb-connection-model": "^17.1.0",
     "mongodb-index-model": "^2.6.1",
     "mongodb-js-errors": "^0.5.0",
     "mongodb-ns": "^2.2.0",


### PR DESCRIPTION
To pull in https://github.com/mongodb-js/connection-model/pull/330

Not quite sure why connection-model here is a dep and not a peer dependency