### PR TITLE
fix: Explicitly pass read preference with db.command commands COMPASS-4539

### DIFF
--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -20,6 +20,13 @@ const {
 
 const debug = require('debug')('mongodb-data-service:instance-detail-helper');
 
+function getReadPreferenceOptions(db) {
+  // `db.command` does not use the read preference set on the
+  // connection, so here we explicitly to specify it in the options.
+  const readPreference = db.s ? db.s.readPreference : ReadPreference.PRIMARY;
+  return { readPreference };
+}
+
 /**
  * aggregates stats across all found databases
  * @param  {Object}   results   async.auto results
@@ -78,7 +85,7 @@ function getBuildInfo(results, done) {
   };
 
   const adminDb = db.databaseName === 'admin' ? db : db.admin();
-  adminDb.command(spec, {}, function(err, res) {
+  adminDb.command(spec, getReadPreferenceOptions(db), function(err, res) {
     if (err) {
       // buildInfo doesn't require any privileges to run, so if it fails,
       // something really went wrong and we should return the error.
@@ -98,7 +105,7 @@ function getCmdLineOpts(results, done) {
   };
 
   const adminDb = db.databaseName === 'admin' ? db : db.admin();
-  adminDb.command(spec, {}, function(err, res) {
+  adminDb.command(spec, getReadPreferenceOptions(db), function(err, res) {
     if (err) {
       debug('getCmdLineOpts failed!', err);
       return done(null, { errmsg: err.message });
@@ -213,7 +220,7 @@ function getHostInfo(results, done) {
   };
 
   const adminDb = db.databaseName === 'admin' ? db : db.admin();
-  adminDb.command(spec, {}, function(err, res) {
+  adminDb.command(spec, getReadPreferenceOptions(db), function(err, res) {
     if (err) {
       if (isNotAuthorized(err)) {
         // if the error is that the user is not authorized, silently ignore it
@@ -253,12 +260,14 @@ function listDatabases(results, done) {
     listDatabases: 1
   };
 
+  const options = getReadPreferenceOptions(db);
+
   const adminDb = db.databaseName === 'admin' ? db : db.admin();
-  adminDb.command(spec, {}, function(err, res) {
+  adminDb.command(spec, options, function(err, res) {
     if (err) {
       if (isNotAuthorized(err)) {
         // eslint-disable-next-line no-shadow
-        adminDb.command({connectionStatus: 1, showPrivileges: 1}, {}, function(err, res) {
+        adminDb.command({connectionStatus: 1, showPrivileges: 1}, options, function(err, res) {
           if (err) {
             done(err);
             return;
@@ -343,7 +352,7 @@ function getDatabase(client, db, name, done) {
     dbStats: 1
   };
 
-  const options = {};
+  const options = getReadPreferenceOptions(db);
   debug('running dbStats for `%s`...', name);
   client.db(name).command(spec, options, function(err, res) {
     if (err) {
@@ -376,8 +385,16 @@ function getDatabases(results, done) {
 function getUserInfo(results, done) {
   const db = results.db;
 
+  const rp = db.s ? db.s.readPreference : ReadPreference.PRIMARY;
+  const options = { readPreference: rp };
+
   // get the user privileges
-  db.command({ connectionStatus: 1, showPrivileges: true }, {}, function(
+  db.command({
+    connectionStatus: 1,
+    showPrivileges: true
+  },
+  options,
+  function(
     err,
     res
   ) {
@@ -394,7 +411,7 @@ function getUserInfo(results, done) {
     }
     const user = res.authInfo.authenticatedUsers[0];
 
-    db.command({ usersInfo: user, showPrivileges: true }, {}, function(
+    db.command({ usersInfo: user, showPrivileges: true }, options, function(
       _err,
       _res
     ) {
@@ -491,15 +508,7 @@ function getDatabaseCollections(db, done) {
 
   const spec = {};
 
-  /**
-   * @note: Durran: For some reason the listCollections call does not take into
-   *  account the read preference that was set on the db instance - it only looks
-   *  in the passed options: https://github.com/mongodb/node-mongodb-native/blob/2.2/lib/db.js#L671
-   */
-  const rp = db.s ? db.s.readPreference : ReadPreference.PRIMARY;
-  const options = { readPreference: rp };
-
-  db.listCollections(spec, options).toArray(function(err, res) {
+  db.listCollections(spec, getReadPreferenceOptions(db)).toArray(function(err, res) {
     if (err) {
       if (isNotAuthorized(err) || isMongosLocalException(err)) {
         // if the error is that the user is not authorized, silently ignore it

--- a/lib/instance-detail-helper.js
+++ b/lib/instance-detail-helper.js
@@ -385,8 +385,7 @@ function getDatabases(results, done) {
 function getUserInfo(results, done) {
   const db = results.db;
 
-  const rp = db.s ? db.s.readPreference : ReadPreference.PRIMARY;
-  const options = { readPreference: rp };
+  const options = getReadPreferenceOptions(db);
 
   // get the user privileges
   db.command({

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -267,7 +267,11 @@ class NativeClient extends EventEmitter {
    * @param {Function} callback - The callback.
    */
   listDatabases(callback) {
-    this.database.admin().command({ listDatabases: 1 }, {}, (error, result) => {
+    this.database.admin().command({
+      listDatabases: 1
+    }, {
+      readPreference: this.model.readPreference
+    }, (error, result) => {
       if (error) {
         return callback(this._translateMessage(error));
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4377,9 +4377,9 @@
       }
     },
     "mongodb-connection-model": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-17.3.0.tgz",
-      "integrity": "sha512-loaAlu6xoEyz7th+f4lkFd07BZZawZYl2Q4EvImAp45kZxo8AH9RmuPCCUsxUlcTHP35i5pDHnCVxzAOb+LB3A==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-18.0.0.tgz",
+      "integrity": "sha512-X5OtFijmCP6HNfsCETEYiBH3M+hvW+p+E7gHqA2CQcVaXaeoojYpX2Nsr7YKwW1oKUbQURfM4szt1Ds9rBAzvw==",
       "dev": true,
       "requires": {
         "ampersand-model": "^8.0.0",
@@ -4387,7 +4387,6 @@
         "async": "^3.1.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.15",
-        "mongodb": "^3.6.3",
         "raf": "^3.4.1",
         "ssh2": "^0.8.7",
         "storage-mixin": "^3.3.4"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "check": "mongodb-js-precommit"
   },
   "peerDependencies": {
-    "mongodb": "^3.6.3",
-    "mongodb-connection-model": "^17.3.0"
+    "mongodb": "3.x",
+    "mongodb-connection-model": "18.x"
   },
   "dependencies": {
     "async": "^3.2.0",
@@ -41,7 +41,7 @@
     "mocha": "^8.2.1",
     "mock-require": "^3.0.3",
     "mongodb": "^3.6.3",
-    "mongodb-connection-model": "^17.3.0",
+    "mongodb-connection-model": "^18.0.0",
     "mongodb-js-precommit": "^2.2.1",
     "mongodb-runner": "^4.8.0",
     "xvfb-maybe": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "mongodb": "3.x",
-    "mongodb-connection-model": "18.x"
+    "mongodb-connection-model": "*"
   },
   "dependencies": {
     "async": "^3.2.0",

--- a/test/instance-detail-helper-mocked.test.js
+++ b/test/instance-detail-helper-mocked.test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { ReadPreference } = require('mongodb');
 const {
   getAllowedCollections,
   getAllowedDatabases,
@@ -380,6 +381,43 @@ describe('instance-detail-helper-mocked', function() {
       listDatabases(results, function(err, res) {
         assert.equal(err, null);
         assert.deepEqual(res, []);
+        done();
+      });
+    });
+    it('should pass the read preference explicity when it is set', function(done) {
+      let passedOptions;
+      results.db = makeMockDB(function(times, command, options, callback) {
+        if (command.listDatabases) {
+          passedOptions = options;
+          return callback(null, { databases: [] });
+        }
+        return callback(null, {});
+      });
+      results.db.s = {
+        readPreference: ReadPreference.SECONDARY
+      };
+
+      listDatabases(results, function() {
+        assert.deepEqual(passedOptions, {
+          readPreference: 'secondary'
+        });
+        done();
+      });
+    });
+    it('defaults to passing the read preference as PRIMARY', function(done) {
+      let passedOptions;
+      results.db = makeMockDB(function(times, command, options, callback) {
+        if (command.listDatabases) {
+          passedOptions = options;
+          return callback(null, { databases: [] });
+        }
+        return callback(null, {});
+      });
+
+      listDatabases(results, function() {
+        assert.deepEqual(passedOptions, {
+          readPreference: ReadPreference.PRIMARY
+        });
         done();
       });
     });


### PR DESCRIPTION
In 3.6.3 the driver updated how operations are run so that operations which have the aspect `WRITE_OPERATION` default to primary instead of using the connection's readPreference:
https://github.com/mongodb/node-mongodb-native/commit/ddcd03d0f934d11a0707dd7d89bc4cb165775f55

This PR updates our use of the `db.command` function which is one of those operations with the aspect `WRITE_OPERATION` to explicitly pass the readPreference which the user set up in Compass. This makes it so we have the same behavior as before and previous direct connections to secondaries don't suddenly stop working.

I think we could do a lot of cleanup here. I'm also not quite sure why we're using `db.command` for listing databases instead of `db.listDatabases`. This should fix the issue though. We also shouldn't be reaching into `db.s.readPreference`. I can create a tech debt ticket 🤔 

I'm not sure if anywhere else in our codebase we rely on `db.command` follow the readPreference of the connection, so I'm looking into that.

Connecting and looking at data in a secondary with a direct connection:
<img width="870" alt="Screen Shot 2020-12-15 at 12 33 00 PM" src="https://user-images.githubusercontent.com/1791149/102250531-ac9d2980-3ed1-11eb-8a77-ff231bebb07c.png">
