### PR TITLE
feat: add saving last seen topology description COMPASS-4568

### DIFF
--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -763,7 +763,6 @@ describe('DataService', function() {
       expect(topology.servers.has('127.0.0.1:27018')).to.equal(true);
 
       expect(topology).to.deep.include({
-        commonWireVersion: 9,
         compatibilityError: null,
         compatible: true,
         heartbeatFrequencyMS: 10000,

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -1,16 +1,16 @@
-var helper = require('./helper');
+const helper = require('./helper');
 
-var assert = helper.assert;
-var expect = helper.expect;
-var eventStream = helper.eventStream;
-var ObjectId = require('bson').ObjectId;
+const assert = helper.assert;
+const expect = helper.expect;
+const eventStream = helper.eventStream;
+const ObjectId = require('bson').ObjectId;
 
-var DataService = require('../lib/data-service');
+const DataService = require('../lib/data-service');
 
 describe('DataService', function() {
   this.slow(10000);
   this.timeout(20000);
-  var service = new DataService(helper.connection);
+  const service = new DataService(helper.connection);
 
   before(function(done) {
     service.connect(done);
@@ -753,6 +753,33 @@ describe('DataService', function() {
           );
         }
       );
+    });
+  });
+
+  describe('#getLastSeenTopology', function() {
+    it('returns the server\'s toplogy description', function() {
+      const topology = service.getLastSeenTopology();
+
+      expect(topology.servers.has('127.0.0.1:27018')).to.equal(true);
+
+      expect(topology).to.deep.include({
+        commonWireVersion: 9,
+        compatibilityError: null,
+        compatible: true,
+        heartbeatFrequencyMS: 10000,
+        localThresholdMS: 15,
+        logicalSessionTimeoutMinutes: 30,
+        maxElectionId: null,
+        maxSetVersion: null,
+        stale: false,
+        type: 'Single',
+        setName: null
+      });
+    });
+
+    it('it returns null when a topology description event hasn\'t yet occured', function() {
+      const testService = new DataService(helper.connection);
+      expect(testService.getLastSeenTopology()).to.equal(null);
     });
   });
 


### PR DESCRIPTION
COMPASS-4568

Previously we were sending the data service with the `data-service-initialized` event. This event would pass a connection which is not guaranteed to successfully connect, and keeping it around in other plugins will cause unexpected errors. We are removing data-service-initialized event to avoid using an unreliable connection. When removing it we still need to listen to the server topology description changed event which occurs before connecting. 
This PR updates the data service to store the most recent server [TopologyDescription](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events) so that we no longer need to listen to a non-connected connection inside of Compass plugins which assume connectivity. (and we can remove the `data-service-initialized` event).

Related:
`compass-connect` PR: https://github.com/mongodb-js/compass-connect/pull/252
`compass-deployment-awareness` PR: https://github.com/mongodb-js/compass-deployment-awareness/pull/183 (will be updated with this new data-service functionality after this is merged.)