### PR TITLE
fix: Use latest connection-model and keep reference to tunnel to be able to close it when disconnecting native client COMPASS-4474

### DIFF
--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -93,6 +93,7 @@ class NativeClient extends EventEmitter {
     super();
     this.model = model;
     this.connectionOptions = null;
+    this.tunnel = null;
   }
 
   /**
@@ -104,6 +105,7 @@ class NativeClient extends EventEmitter {
   connect(done) {
     debug('connecting...');
 
+    this.tunnel = null;
     this.connectionOptions = null;
     this.isWritable = false;
     this.isMongos = false;
@@ -111,12 +113,13 @@ class NativeClient extends EventEmitter {
     connect(
       this.model,
       this.setupListeners.bind(this),
-      (err, _client, connectionOptions) => {
+      (err, _client, tunnel, connectionOptions) => {
         if (err) {
           return done(this._translateMessage(err));
         }
 
         this.connectionOptions = connectionOptions;
+        this.tunnel = tunnel;
 
         this.isWritable = this.client.isWritable;
         this.isMongos = this.client.isMongos;
@@ -298,6 +301,8 @@ class NativeClient extends EventEmitter {
    *
    * @param {String} databaseName - The database name.
    * @param {Function} callback - The callback.
+   *
+   * @returns {void}
    */
   collections(databaseName, callback) {
     if (databaseName === SYSTEM) {
@@ -521,9 +526,20 @@ class NativeClient extends EventEmitter {
 
   /**
    * Disconnect the client.
+   * @param {Function} callback
    */
   disconnect(callback) {
-    this.client.close(true, callback);
+    this.client.close(true, err => {
+      if (this.tunnel) {
+        debug('mongo client closed. shutting down ssh tunnel');
+        this.tunnel.close().finally(() => {
+          debug('ssh tunnel stopped');
+          callback(err);
+        });
+      } else {
+        return callback(err);
+      }
+    });
   }
 
   /**

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -92,8 +92,13 @@ class NativeClient extends EventEmitter {
   constructor(model) {
     super();
     this.model = model;
+
     this.connectionOptions = null;
     this.tunnel = null;
+
+    this.isWritable = false;
+    this.isMongos = false;
+    this._isConnected = false;
   }
 
   /**
@@ -105,16 +110,28 @@ class NativeClient extends EventEmitter {
   connect(done) {
     debug('connecting...');
 
-    this.tunnel = null;
-    this.connectionOptions = null;
-    this.isWritable = false;
-    this.isMongos = false;
+    if (this._isConnected) {
+      setImmediate(() => {
+        done(
+          new Error(
+            'Connect method has been called more than once without disconnecting.'
+          )
+        );
+      });
+
+      return this;
+    }
+
+    // Not really true at that point, we are doing it just so we don't allow
+    // simultaneous syncronous calls to the connect method
+    this._isConnected = true;
 
     connect(
       this.model,
       this.setupListeners.bind(this),
       (err, _client, tunnel, connectionOptions) => {
         if (err) {
+          this._isConnected = false;
           return done(this._translateMessage(err));
         }
 
@@ -131,6 +148,7 @@ class NativeClient extends EventEmitter {
 
         this.client.on('status', (evt) => this.emit('status', evt));
         this.database = this.client.db(this.model.ns || ADMIN);
+
         done(null, this);
       }
     );
@@ -533,10 +551,12 @@ class NativeClient extends EventEmitter {
       if (this.tunnel) {
         debug('mongo client closed. shutting down ssh tunnel');
         this.tunnel.close().finally(() => {
+          this._cleanup();
           debug('ssh tunnel stopped');
           callback(err);
         });
       } else {
+        this._cleanup();
         return callback(err);
       }
     });
@@ -1264,6 +1284,15 @@ class NativeClient extends EventEmitter {
       error.message = error.message || error.err || error.errmsg;
     }
     return error;
+  }
+
+  _cleanup() {
+    this.client = null;
+    this.connectionOptions = null;
+    this.tunnel = null;
+    this.isWritable = false;
+    this.isMongos = false;
+    this._isConnected = false;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,6 +186,15 @@
         }
       }
     },
+    "@mongodb-js/ssh-tunnel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/ssh-tunnel/-/ssh-tunnel-1.2.0.tgz",
+      "integrity": "sha512-tG8CVPInP3TKUeaBFrNugQ14l5GwC4mIMuuX14aZmSCZ2olnBsPFreD5+CtMywQyUJqGkZWJDbAb6/grrn8vQw==",
+      "dev": true,
+      "requires": {
+        "ssh2": "^0.8.9"
+      }
+    },
     "@mongodb-js/triejs": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
@@ -4734,11 +4743,12 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
     },
     "mongodb-connection-model": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-18.0.0.tgz",
-      "integrity": "sha512-X5OtFijmCP6HNfsCETEYiBH3M+hvW+p+E7gHqA2CQcVaXaeoojYpX2Nsr7YKwW1oKUbQURfM4szt1Ds9rBAzvw==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-19.1.0.tgz",
+      "integrity": "sha512-7SgZLpozwudXjPeiqVQrd8gM+CtJnd1go897SfExOdL+S3UVdhBdhyI/1yBNwjpZbmK34qDm8OP3J9IGur+H1g==",
       "dev": true,
       "requires": {
+        "@mongodb-js/ssh-tunnel": "^1.2.0",
         "ampersand-model": "^8.0.0",
         "ampersand-rest-collection": "^6.0.0",
         "async": "^3.1.0",
@@ -5327,9 +5337,9 @@
       }
     },
     "node-abi": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.20.0.tgz",
+      "integrity": "sha512-6ldtfVR5l3RS8D0aT+lj/uM2Vv/PGEkeWzt2tl8DFBsGY/IuVnAIHl+dG6C14NlWClVv7Rn2+ZDvox+35Hx2Kg==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
@@ -6554,9 +6564,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.3",
@@ -6567,9 +6577,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "dev": true,
           "requires": {
             "buffer": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "peerDependencies": {
     "mongodb": "3.x",
-    "mongodb-connection-model": "*"
+    "mongodb-connection-model": ">=19.1.0"
   },
   "dependencies": {
     "async": "^3.2.0",
@@ -52,7 +52,7 @@
     "mocha": "^8.2.1",
     "mock-require": "^3.0.3",
     "mongodb": "^3.6.3",
-    "mongodb-connection-model": "^18.0.0",
+    "mongodb-connection-model": "^19.1.0",
     "mongodb-runner": "^4.8.0",
     "pre-commit": "^1.2.2",
     "sinon": "^9.2.3",

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -71,7 +71,7 @@ describe('NativeClient', function() {
             mockedClient.emit('topologyDescriptionChanged', {
               newDescription: _topologyDescription
             });
-            cb(null, mockedClient, _connectionOptions);
+            cb(null, mockedClient, null, _connectionOptions);
           }
         };
       }


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/connection-model/pull/352 that makes sure that when `connection-model` returns a tunnel during connect, we close it before resolving a `disconnect` callback