### PR TITLE
fix(native-client): Set sort by using Cursor.sort method instead of passing it as a find option COMPASS-4258

### DIFF
--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -643,15 +643,20 @@ class NativeClient extends EventEmitter {
    * @param {Object} options - The query options.
    * @param {Function} callback - The callback.
    */
-  find(ns, filter, options, callback) {
-    this._collection(ns)
-      .find(filter, options)
-      .toArray((error, documents) => {
-        if (error) {
-          return callback(this._translateMessage(error));
-        }
-        callback(null, documents);
-      });
+  find(ns, filter = {}, options = {}, callback = () => {}) {
+    // Workaround for https://jira.mongodb.org/browse/NODE-3173
+    const sort = options.sort;
+    delete options.sort;
+    let cursor = this._collection(ns).find(filter, options);
+    if (sort) {
+      cursor = cursor.sort(sort);
+    }
+    cursor.toArray((error, documents) => {
+      if (error) {
+        return callback(this._translateMessage(error));
+      }
+      callback(null, documents);
+    });
   }
 
   /**

--- a/test/helper.js
+++ b/test/helper.js
@@ -18,11 +18,19 @@ module.exports.connection = new Connection({
 
 module.exports.insertTestDocuments = function(client, callback) {
   var collection = client.database.collection('test');
-  collection.insertMany([{
-    a: 1
-  }, {
-    a: 2
-  }], callback);
+  collection.insertMany(
+    [
+      {
+        1: 'a',
+        a: 1
+      },
+      {
+        2: 'a',
+        a: 2
+      }
+    ],
+    callback
+  );
 };
 
 module.exports.deleteTestDocuments = function(client, callback) {

--- a/test/native-client.test.js
+++ b/test/native-client.test.js
@@ -409,6 +409,27 @@ describe('NativeClient', function() {
         });
       });
     });
+
+    context('when array sort is provided', function() {
+      it('returns documents with correct sort order', function(done) {
+        const sort = [
+          ['2', -1],
+          ['1', -1]
+        ];
+
+        client.find(
+          'data-service.test',
+          {},
+          { sort },
+          function(error, docs) {
+            assert.strictEqual(null, error);
+            expect(docs[0]).to.have.nested.property('2', 'a');
+            expect(docs[1]).to.have.nested.property('1', 'a');
+            done();
+          }
+        );
+      });
+    });
   });
 
   describe('#fetch', function() {


### PR DESCRIPTION
There seems to be a bug in driver v3.6 that doesn't pass `sort` correctly to the server when passed as an option of `find` method. This PR adds a workaround for this by calling `sort` method on the cursor instead which driver handles differently