### PR TITLE
feat: Add isConnected method to dataService to allow easy access to connection status of the internal MongoClient COMPASS-4741

### DIFF
--- a/lib/data-service.js
+++ b/lib/data-service.js
@@ -582,6 +582,10 @@ class DataService extends EventEmitter {
     return this.client.killSession(...args);
   }
 
+  isConnected() {
+    return this.client.isConnected();
+  }
+
   /**
    * When Node supports ES6 default values for arguments, this can go away.
    *

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -105,7 +105,7 @@ class NativeClient extends EventEmitter {
     // This is better than just returning internal `_isConnected` as this
     // actually shows when the client is available on the NativeClient instance
     // and connected
-    return this.client && this.client.isConnected();
+    return !!(this.client && this.client.isConnected());
   }
 
   /**
@@ -554,6 +554,15 @@ class NativeClient extends EventEmitter {
    * @param {Function} callback
    */
   disconnect(callback) {
+    // This follows MongoClient behavior where calling `close` on client that is
+    // not connected
+    if (!this.client) {
+      setImmediate(() => {
+        callback();
+      });
+      return;
+    }
+
     this.client.close(true, err => {
       if (this.tunnel) {
         debug('mongo client closed. shutting down ssh tunnel');

--- a/lib/native-client.js
+++ b/lib/native-client.js
@@ -101,6 +101,13 @@ class NativeClient extends EventEmitter {
     this._isConnected = false;
   }
 
+  isConnected() {
+    // This is better than just returning internal `_isConnected` as this
+    // actually shows when the client is available on the NativeClient instance
+    // and connected
+    return this.client && this.client.isConnected();
+  }
+
   /**
    * Connect to the server.
    *

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -17,9 +17,37 @@ describe('DataService', function() {
     service.disconnect(done);
   });
 
+  // Each test gets its own service so that we can connect/disconnect it freely
   describe('#isConnected', () => {
-    it('returns true if client is connected', () => {
-      expect(service.isConnected()).to.equal(true);
+    let _service;
+
+    it('returns false when not connected initially', () => {
+      _service = new DataService(helper.connection);
+      expect(_service.isConnected()).to.equal(false);
+    });
+
+    it('returns true if client is connected', (done) => {
+      _service = new DataService(helper.connection);
+      _service.connect(() => {
+        expect(_service.isConnected()).to.equal(true);
+        done();
+      });
+    });
+
+    it('returns false if client is disconnected', (done) => {
+      _service = new DataService(helper.connection);
+      _service.connect(() => {
+        _service.disconnect(() => {
+          expect(_service.isConnected()).to.equal(false);
+          done();
+        });
+      });
+    });
+
+    afterEach((done) => {
+      if (_service) {
+        _service.disconnect(done);
+      }
     });
   });
 

--- a/test/data-service.test.js
+++ b/test/data-service.test.js
@@ -17,6 +17,12 @@ describe('DataService', function() {
     service.disconnect(done);
   });
 
+  describe('#isConnected', () => {
+    it('returns true if client is connected', () => {
+      expect(service.isConnected()).to.equal(true);
+    });
+  });
+
   describe('#deleteOne', function() {
     it('deletes the document from the collection', function(done) {
       service.insertOne(


### PR DESCRIPTION
We want to expose this information so that we can check if client is connected before using any methods on it in compass plugins